### PR TITLE
Hotfix - update example amounts to exclude sales tax

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -50,7 +50,7 @@ $taxjar = TaxJar\Client::withApiKey("9e0cd62a22f451701f29c3bde214");
 curl "API_ENDPOINT" \
   -H "Authorization: Token token="9e0cd62a22f451701f29c3bde214""
 
-or 
+or
 
 curl "API_ENDPOINT" \
   -H "Authorization: Bearer 9e0cd62a22f451701f29c3bde214"
@@ -177,18 +177,18 @@ curl https://api.taxjar.com/v2/categories \
 ```ruby
 [
   #<Taxjar::Category:0x007f081dc3e278 @attrs={
-    :name => "Digital Goods", 
-    :product_tax_code => "31000", 
+    :name => "Digital Goods",
+    :product_tax_code => "31000",
     :description => "Digital products transferred electronically."
-  }>, 
+  }>,
   #<Taxjar::Category:0x007f081dc3de90 @attrs={
-    :name => "Clothing", 
-    :product_tax_code => "20010", 
+    :name => "Clothing",
+    :product_tax_code => "20010",
     :description => "All human wearing apparel suitable for general use"
-  }>, 
+  }>,
   #<Taxjar::Category:0x007f081dc3da80 @attrs={
     :name => "Non-Prescription",
-    :product_tax_code => "51010", 
+    :product_tax_code => "51010",
     :description => "Drugs for human use without a prescription"
   }>
 ]
@@ -309,7 +309,7 @@ $rates = $taxjar->ratesForLocation('00150', [
 # United States (ZIP+4)
 curl https://api.taxjar.com/v2/rates/90404-3370 \
   -H "Authorization: Bearer 9e0cd62a22f451701f29c3bde214"
-  
+
 # United States (ZIP w/ Optional Params)
 curl https://api.taxjar.com/v2/rates/90404 \
   -H "Authorization: Bearer 9e0cd62a22f451701f29c3bde214" \
@@ -372,7 +372,7 @@ curl https://api.taxjar.com/v2/rates/00150 \
 
 ```ruby
 #<Taxjar::Rate:0x007fc47056a928 @attrs={
-  :zip => "90404", 
+  :zip => "90404",
   :state => "CA",
   :state_rate => 0.065,
   :county => "LOS ANGELES",
@@ -668,7 +668,7 @@ line_items[][product_tax_code] | string | optional | Product tax code for the it
 line_items[][unit_price] | long | optional | Unit price for the item.
 line_items[][discount] | long | optional | Discount amount for the item.
 
-#### Notes 
+#### Notes
 
 - *Either `amount` or `line_items` parameters are required to perform tax calculations.*
 
@@ -850,7 +850,7 @@ curl https://api.taxjar.com/v2/transactions/orders/123 \
     "to_state": "CA",
     "to_city": "LOS ANGELES",
     "to_street": "123 Palm Grove Ln",
-    "amount": "17.95",
+    "amount": "17.0",
     "shipping": "2.0",
     "sales_tax": "0.95",
     "line_items": [
@@ -884,7 +884,7 @@ curl https://api.taxjar.com/v2/transactions/orders/123 \
   :to_state => "CA",
   :to_city => "LOS ANGELES",
   :to_street => "123 Palm Grove Ln",
-  :amount => 17.95,
+  :amount => 17.0,
   :shipping => 2,
   :sales_tax => 0.95,
   :line_items => [
@@ -948,7 +948,7 @@ order = client.create_order({
   :to_state => 'CA',
   :to_city => 'Los Angeles',
   :to_street => '123 Palm Grove Ln',
-  :amount => 17.45,
+  :amount => 16.5,
   :shipping => 1.5,
   :sales_tax => 0.95,
   :line_items => [{:quantity => 1,
@@ -970,7 +970,7 @@ taxjar.createOrder({
   'to_state': 'CA',
   'to_city': 'Los Angeles',
   'to_street': '123 Palm Grove Ln',
-  'amount': 17.45,
+  'amount': 16.5,
   'shipping': 1.5,
   'sales_tax': 0.95,
   'line_items': [
@@ -998,7 +998,7 @@ $order = $taxjar->createOrder([
   'to_state' => 'CA',
   'to_city' => 'Los Angeles',
   'to_street' => '123 Palm Grove Ln',
-  'amount' => 17.45,
+  'amount' => 16.5,
   'shipping' => 1.5,
   'sales_tax' => 0.95,
   'line_items' => [
@@ -1023,7 +1023,7 @@ curl https://api.taxjar.com/v2/transactions/orders \
   -d to_state="CA" \
   -d to_city="Los Angeles" \
   -d to_street="123 Palm Grove Ln" \
-  -d amount=17.45 \
+  -d amount=16.5 \
   -d shipping=1.5 \
   -d sales_tax=0.95 \
   -d "line_items[][quantity]=1 \
@@ -1046,7 +1046,7 @@ curl https://api.taxjar.com/v2/transactions/orders \
     "to_state": "CA",
     "to_city": "LOS ANGELES",
     "to_street": "123 Palm Grove Ln",
-    "amount": "17.45",
+    "amount": "16.5",
     "shipping": "1.5",
     "sales_tax": "0.95",
     "line_items": [
@@ -1080,7 +1080,7 @@ curl https://api.taxjar.com/v2/transactions/orders \
   :to_state => "CA",
   :to_city => "LOS ANGELES",
   :to_street => "123 Palm Grove Ln",
-  :amount => 15.02,
+  :amount => 16.5,
   :shipping => 1.5,
   :sales_tax => 0.95,
   :line_items => [
@@ -1092,7 +1092,7 @@ curl https://api.taxjar.com/v2/transactions/orders \
       :description => "Fuzzy Widget",
       :unit_price => "15.0",
       :discount => "0.0",
-      :sales_tax => "0.85"
+      :sales_tax => "0.95"
     }
   ]
 }>
@@ -1166,8 +1166,8 @@ client = Taxjar::Client.new(api_key: "9e0cd62a22f451701f29c3bde214")
 
 order = client.update_order({
   :transaction_id => '123',
-  :amount => 17.45,
-  :shipping => 1.5,
+  :amount => 17.0,
+  :shipping => 2.0,
   :line_items => [{:quantity => 1,
                    :product_identifier => '12-34243-0',
                    :description => 'Heavy Widget',
@@ -1182,8 +1182,8 @@ var taxjar = require("taxjar")("9e0cd62a22f451701f29c3bde214");
 
 taxjar.updateOrder({
   'transaction_id': '123',
-  'amount': 17.45,
-  'shipping': 1.5,
+  'amount': 17.0,
+  'shipping': 2.0,
   'line_items': [
     {
       'quantity': 1,
@@ -1204,7 +1204,7 @@ $taxjar = TaxJar\Client::withApiKey("9e0cd62a22f451701f29c3bde214");
 
 $order = $taxjar->updateOrder([
   'transaction_id' => '123',
-  'amount' => 17.95,
+  'amount' => 17.0,
   'shipping' => 2.0,
   'line_items' => [
     [
@@ -1223,8 +1223,8 @@ $order = $taxjar->updateOrder([
 curl https://api.taxjar.com/v2/transactions/orders/123 \
   -H "Authorization: Bearer 9e0cd62a22f451701f29c3bde214" \
   -d transaction_id="123" \
-  -d amount=17.45 \
-  -d shipping=1.5 \
+  -d amount=17.0 \
+  -d shipping=2.0 \
   -d "line_items[][quantity]=1 \
   &line_items[][product_identifier]='12-34234-0' \
   &line_items[][description]='Heavy Widget' \
@@ -1247,7 +1247,7 @@ curl https://api.taxjar.com/v2/transactions/orders/123 \
     "to_state": "CA",
     "to_city": "LOS ANGELES",
     "to_street": "123 Palm Grove Ln",
-    "amount": "17.95",
+    "amount": "17.0",
     "shipping": "2.0",
     "sales_tax": "0.95",
     "line_items": [
@@ -1281,7 +1281,7 @@ curl https://api.taxjar.com/v2/transactions/orders/123 \
   :to_state => "CA",
   :to_city => "LOS ANGELES",
   :to_street => "123 Palm Grove Ln",
-  :amount => 17.95,
+  :amount => 17.0,
   :shipping => 2.0,
   :sales_tax => 0.95,
   :line_items => [
@@ -1401,7 +1401,7 @@ curl https://api.taxjar.com/v2/transactions/orders/123 \
     "to_state": "CA",
     "to_city": "LOS ANGELES",
     "to_street": "123 Palm Grove Ln",
-    "amount": "17.95",
+    "amount": "17.0",
     "shipping": "2.0",
     "sales_tax": "0.95",
     "line_items": [
@@ -1435,7 +1435,7 @@ curl https://api.taxjar.com/v2/transactions/orders/123 \
   :to_state => "CA",
   :to_city => "LOS ANGELES",
   :to_street => "123 Palm Grove Ln",
-  :amount => 17.95,
+  :amount => 17.0,
   :shipping => 2.0,
   :sales_tax => 0.95,
   :line_items => [
@@ -1619,7 +1619,7 @@ curl https://api.taxjar.com/v2/transactions/refunds/321 \
     "to_state": "CA",
     "to_city": "LOS ANGELES",
     "to_street": "123 Palm Grove Ln",
-    "amount": "17.95",
+    "amount": "17.0",
     "shipping": "2.0",
     "sales_tax": "0.95",
     "line_items": [
@@ -1653,7 +1653,7 @@ curl https://api.taxjar.com/v2/transactions/refunds/321 \
   :to_state => "CA",
   :to_city => "LOS ANGELES",
   :to_street => "123 Palm Grove Ln",
-  :amount => 17.95,
+  :amount => 17.0,
   :shipping => 2.0,
   :sales_tax => 0.95,
   :line_items => [
@@ -1718,7 +1718,7 @@ order = client.create_refund({
   :to_state => 'CA',
   :to_city => 'Los Angeles',
   :to_street => '123 Palm Grove Ln',
-  :amount => 17.45,
+  :amount => 16.5,
   :shipping => 1.5,
   :sales_tax => 0.95,
   :line_items => [{:quantity => 1,
@@ -1741,7 +1741,7 @@ taxjar.createRefund({
   'to_state': 'CA',
   'to_city': 'Los Angeles',
   'to_street': '123 Palm Grove Ln',
-  'amount': 17.45,
+  'amount': 16.5,
   'shipping': 1.5,
   'sales_tax': 0.95,
   'line_items': [
@@ -1770,7 +1770,7 @@ $refund = $taxjar->createRefund([
   'to_state' => 'CA',
   'to_city' => 'Los Angeles',
   'to_street' => '123 Palm Grove Ln',
-  'amount' => 17.45,
+  'amount' => 16.5,
   'shipping' => 1.5,
   'sales_tax' => 0.95,
   'line_items' => [
@@ -1796,7 +1796,7 @@ curl https://api.taxjar.com/v2/transactions/refunds \
   -d to_state="CA" \
   -d to_city="Los Angeles" \
   -d to_street="123 Palm Grove Ln" \
-  -d amount=17.45 \
+  -d amount=16.5 \
   -d shipping=1.5 \
   -d sales_tax=0.95 \
   -d "line_items[][quantity]=1 \
@@ -1820,7 +1820,7 @@ curl https://api.taxjar.com/v2/transactions/refunds \
     "to_state": "CA",
     "to_city": "LOS ANGELES",
     "to_street": "123 Palm Grove Ln",
-    "amount": "17.45",
+    "amount": "16.5",
     "shipping": "1.5",
     "sales_tax": "0.95",
     "line_items": [
@@ -1854,7 +1854,7 @@ curl https://api.taxjar.com/v2/transactions/refunds \
   :to_state => "CA",
   :to_city => "LOS ANGELES",
   :to_street => "123 Palm Grove Ln",
-  :amount => 17.95,
+  :amount => 17.0,
   :shipping => 2.0,
   :sales_tax => 0.95,
   :line_items => [
@@ -1941,7 +1941,7 @@ client = Taxjar::Client.new(api_key: "9e0cd62a22f451701f29c3bde214")
 
 order = client.update_refund({
   :transaction_id => '321',
-  :amount => 17.95,
+  :amount => 17.0,
   :shipping => 2.0,
   :sales_tax => 0.95,
   :line_items => [{:quantity => 1,
@@ -1957,7 +1957,7 @@ var taxjar = require("taxjar")("9e0cd62a22f451701f29c3bde214");
 
 taxjar.updateRefund({
   'transaction_id': '123',
-  'amount': 17.95,
+  'amount': 17.0,
   'shipping': 2.0,
   'line_items': [
     {
@@ -1978,7 +1978,7 @@ $taxjar = TaxJar\Client::withApiKey("9e0cd62a22f451701f29c3bde214");
 
 $refund = $taxjar->updateRefund([
   'transaction_id' => '321',
-  'amount' => 17.95,
+  'amount' => 17.0,
   'shipping' => 2.0,
   'line_items' => [
     [
@@ -1996,7 +1996,7 @@ $refund = $taxjar->updateRefund([
 curl https://api.taxjar.com/v2/transactions/refunds/321 \
   -H "Authorization: Bearer 9e0cd62a22f451701f29c3bde214" \
   -d transaction_id="321" \
-  -d amount=17.95 \
+  -d amount=17.0 \
   -d shipping=2.0 \
   -d sales_tax=0.95 \
   -d "line_items[][quantity]=1 \
@@ -2021,7 +2021,7 @@ curl https://api.taxjar.com/v2/transactions/refunds/321 \
     "to_state": "CA",
     "to_city": "LOS ANGELES",
     "to_street": "123 Palm Grove Ln",
-    "amount": "17.95",
+    "amount": "17.0",
     "shipping": "2.0",
     "sales_tax": "0.95",
     "line_items": [
@@ -2055,7 +2055,7 @@ curl https://api.taxjar.com/v2/transactions/refunds/321 \
   :to_state => "CA",
   :to_city => "LOS ANGELES",
   :to_street => "123 Palm Grove Ln",
-  :amount => 17.95,
+  :amount => 17.0,
   :shipping => 2.0,
   :sales_tax => 0.95,
   :line_items => [
@@ -2177,7 +2177,7 @@ curl https://api.taxjar.com/v2/transactions/refunds/321 \
     "to_state": "CA",
     "to_city": "LOS ANGELES",
     "to_street": "123 Palm Grove Ln",
-    "amount": "17.95",
+    "amount": "17.0",
     "shipping": "2.0",
     "sales_tax": "0.95",
     "line_items": [
@@ -2211,7 +2211,7 @@ curl https://api.taxjar.com/v2/transactions/refunds/321 \
   :to_state => "CA",
   :to_city => "LOS ANGELES",
   :to_street => "123 Palm Grove Ln",
-  :amount => 17.95,
+  :amount => 17.0,
   :shipping => 2.0,
   :sales_tax => 0.95,
   :line_items => [


### PR DESCRIPTION
Hi,

This hotfix excludes sales tax from all the example amounts in API requests and responses.  I also changed the shipping amount for all 'heavy widget' examples to be 2.0 for consistency.