### PR TITLE
Changed 400 error documentation to properly describe the proper way o…

### DIFF
--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -175,7 +175,7 @@ Additionally, we provide specific 400 error messages for invalid data:
 
 ### Transactions
 
-- `amount` param does not equal sum of `line_items` + `shipping`
+- `amount` param does not equal sum of `line_items` excluding `shipping`
 - `line_items[][description]` param exceeds limit of 255 characters
 
 ## 401 Unauthorized


### PR DESCRIPTION
…f calculating amount

@fastdivision I believe that the way the amount is described in the 400 error code is no longer correct.  It should match the guidelines in the POST /taxes route.

<img width="446" alt="screen shot 2017-10-06 at 5 35 08 pm" src="https://user-images.githubusercontent.com/10674091/31302434-0041a9c6-aabf-11e7-83aa-21e81b4c1194.png">
