### PR TITLE
Tax Jurisdiction Names

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,6 +2,12 @@
 
 Stay on top of new developer-facing features, accuracy improvements, and bug fixes for our sales tax API. Have a request? Encounter an issue? [We'd love to hear your feedback.](mailto:support@taxjar.com)
 
+### September 2018
+
+#### 2018-09-12
+
+* <span class="badge badge--put">Platform</span> Added jurisdiction information to taxes endpoint.
+
 ### August 2018
 
 #### 2018-08-05

--- a/source/reference.md
+++ b/source/reference.md
@@ -3914,6 +3914,12 @@ $ curl https://api.taxjar.com/v2/taxes \
           "special_district_amount": 0.38
         }
       ]
+    },
+    "jurisdictions": {
+      "country": "US",
+      "state": "CA",
+      "county": "LOS ANGELES",
+      "city": "LOS ANGELES"
     }
   }
 }
@@ -4074,6 +4080,11 @@ $ curl https://api.taxjar.com/v2/taxes \
       },
       "tax_collectable": 2.15,
       "taxable_amount": 16.5
+    },
+    "jurisdictions": {
+      "country": "CA",
+      "state": "ON",
+      "city": "TORONTO"
     }
   }
 }
@@ -4358,6 +4369,10 @@ $ curl https://api.taxjar.com/v2/taxes \
       },
       "tax_collectable": 3.3,
       "taxable_amount": 16.5
+    },
+    "jurisdictions": {
+      "country": "FR",
+      "city": "MARSEILLE"
     }
   }
 }
@@ -4509,6 +4524,12 @@ $ curl https://api.taxjar.com/v2/taxes \
       "state_taxable_amount": 16.5,
       "tax_collectable": 1.36,
       "taxable_amount": 16.5
+    },
+    "jurisdictions": {
+      "country": "US",
+      "state": "TX",
+      "county": "TRAVIS",
+      "city": "AUSTIN"
     }
   }
 }
@@ -4697,6 +4718,12 @@ $ curl https://api.taxjar.com/v2/taxes \
       "state_taxable_amount": 15,
       "tax_collectable": 0.94,
       "taxable_amount": 15
+    },
+    "jurisdictions": {
+      "country": "US",
+      "state": "MA",
+      "county": "WORCESTER",
+      "city": "WORCESTER"
     }
   }
 }
@@ -4886,6 +4913,12 @@ $ curl https://api.taxjar.com/v2/taxes \
       "state_taxable_amount": 7.99,
       "tax_collectable": 1.98,
       "taxable_amount": 37.93
+    },
+    "jurisdictions": {
+      "country": "US",
+      "state": "NY",
+      "county": "PUTNAM",
+      "city": "MAHOPAC"
     }
   }
 }
@@ -5128,6 +5161,12 @@ $ curl https://api.taxjar.com/v2/taxes \
       "state_taxable_amount": 0,
       "tax_collectable": 0,
       "taxable_amount": 0
+    },
+    "jurisdictions": {
+      "country": "US",
+      "state": "CA",
+      "county": "LOS ANGELES",
+      "city": "LOS ANGELES"
     }
   }
 }
@@ -5353,6 +5392,12 @@ $ curl https://api.taxjar.com/v2/taxes \
       "state_taxable_amount": 17.94,
       "tax_collectable": 1.58,
       "taxable_amount": 17.94
+    },
+    "jurisdictions": {
+      "country": "US",
+      "state": "WA",
+      "county": "SPOKANE",
+      "city": "SPOKANE"
     }
   }
 }
@@ -5626,6 +5671,7 @@ has_nexus | bool | Whether or not you have [nexus](https://blog.taxjar.com/sales
 freight_taxable | bool | Freight taxability for the order.
 tax_source | string | [Origin-based or destination-based](https://blog.taxjar.com/charging-sales-tax-rates/) sales tax collection.
 breakdown | object | Breakdown of rates by jurisdiction for the order, shipping, and individual line items. If `has_nexus` is false or no line items are provided, no breakdown is returned in the response.
+jurisdictions | object | Relevant jurisdictions.
 
 <h4 id="us-taxes-breakdown-attributes"><span class="flag-icon flag-icon-us"></span>&nbsp; United States Breakdown Attributes</h4>
 
@@ -5648,6 +5694,7 @@ special_tax_rate | decimal | Special district sales tax rate for given location.
 special_district_tax_collectable | decimal | Amount of sales tax to collect for the special district.
 shipping | object | Breakdown of shipping rates if applicable.
 line_items | object | Breakdown of rates by line item if applicable.
+jurisdictions | object | Relevant jurisdictions.
 
 <h4 id="canada-taxes-breakdown-attributes"><span class="flag-icon flag-icon-ca"></span>&nbsp; Canada Breakdown Attributes</h4>
 
@@ -5664,6 +5711,7 @@ qst_tax_rate | decimal | Quebec sales tax rate for given location.
 qst | decimal | Amount of Quebec sales tax to collect for given location.
 shipping | object | Breakdown of shipping rates if applicable.
 line_items | object | Breakdown of rates by line item if applicable.
+jurisdictions | object | Relevant jurisdictions.
 
 <h4 id="international-taxes-breakdown-attributes"><span class="flag-icon flag-icon-eu"></span> <span class="flag-icon flag-icon-au"></span>&nbsp; International Breakdown Attributes</h4>
 
@@ -5674,6 +5722,7 @@ country_tax_rate | decimal | Country sales tax rate for given location
 country_tax_collectable | decimal | Amount of sales tax to collect for the country.
 shipping | object | Breakdown of shipping rates if applicable.
 line_items | object | Breakdown of rates by line item if applicable.
+jurisdictions | object | Relevant jurisdictions.
 
 ## Transactions
 

--- a/source/reference.md
+++ b/source/reference.md
@@ -3878,6 +3878,12 @@ $ curl https://api.taxjar.com/v2/taxes \
     "has_nexus": true,
     "freight_taxable": false,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "US",
+      "state": "CA",
+      "county": "LOS ANGELES",
+      "city": "LOS ANGELES"
+    },
     "breakdown": {
       "taxable_amount": 15,
       "tax_collectable": 1.35,
@@ -3914,12 +3920,6 @@ $ curl https://api.taxjar.com/v2/taxes \
           "special_district_amount": 0.38
         }
       ]
-    },
-    "jurisdictions": {
-      "country": "US",
-      "state": "CA",
-      "county": "LOS ANGELES",
-      "city": "LOS ANGELES"
     }
   }
 }
@@ -4036,6 +4036,11 @@ $ curl https://api.taxjar.com/v2/taxes \
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "CA",
+      "state": "ON",
+      "city": "TORONTO"
+    },
     "breakdown": {
       "combined_tax_rate": 0.13,
       "gst": 0.83,
@@ -4080,11 +4085,6 @@ $ curl https://api.taxjar.com/v2/taxes \
       },
       "tax_collectable": 2.15,
       "taxable_amount": 16.5
-    },
-    "jurisdictions": {
-      "country": "CA",
-      "state": "ON",
-      "city": "TORONTO"
     }
   }
 }
@@ -4219,6 +4219,9 @@ $ curl https://api.taxjar.com/v2/taxes \
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "AU"
+    },
     "breakdown": {
       "combined_tax_rate": 0.1,
       "country_tax_collectable": 1.65,
@@ -4343,6 +4346,10 @@ $ curl https://api.taxjar.com/v2/taxes \
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "FR",
+      "city": "MARSEILLE"
+    },
     "breakdown": {
       "combined_tax_rate": 0.2,
       "country_tax_collectable": 3.3,
@@ -4369,10 +4376,6 @@ $ curl https://api.taxjar.com/v2/taxes \
       },
       "tax_collectable": 3.3,
       "taxable_amount": 16.5
-    },
-    "jurisdictions": {
-      "country": "FR",
-      "city": "MARSEILLE"
     }
   }
 }
@@ -4471,6 +4474,12 @@ $ curl https://api.taxjar.com/v2/taxes \
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "origin",
+    "jurisdictions": {
+      "country": "US",
+      "state": "TX",
+      "county": "TRAVIS",
+      "city": "AUSTIN"
+    },
     "breakdown": {
       "city_tax_collectable": 0.17,
       "city_tax_rate": 0.01,
@@ -4524,12 +4533,6 @@ $ curl https://api.taxjar.com/v2/taxes \
       "state_taxable_amount": 16.5,
       "tax_collectable": 1.36,
       "taxable_amount": 16.5
-    },
-    "jurisdictions": {
-      "country": "US",
-      "state": "TX",
-      "county": "TRAVIS",
-      "city": "AUSTIN"
     }
   }
 }
@@ -4682,6 +4685,12 @@ $ curl https://api.taxjar.com/v2/taxes \
     "has_nexus": true,
     "freight_taxable": false,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "US",
+      "state": "MA",
+      "county": "WORCESTER",
+      "city": "WORCESTER"
+    },
     "breakdown": {
       "city_tax_collectable": 0,
       "city_tax_rate": 0,
@@ -4718,12 +4727,6 @@ $ curl https://api.taxjar.com/v2/taxes \
       "state_taxable_amount": 15,
       "tax_collectable": 0.94,
       "taxable_amount": 15
-    },
-    "jurisdictions": {
-      "country": "US",
-      "state": "MA",
-      "county": "WORCESTER",
-      "city": "WORCESTER"
     }
   }
 }
@@ -4842,6 +4845,12 @@ $ curl https://api.taxjar.com/v2/taxes \
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "US",
+      "state": "NY",
+      "county": "PUTNAM",
+      "city": "MAHOPAC"
+    },
     "breakdown": {
       "city_tax_collectable": 0,
       "city_tax_rate": 0,
@@ -4913,12 +4922,6 @@ $ curl https://api.taxjar.com/v2/taxes \
       "state_taxable_amount": 7.99,
       "tax_collectable": 1.98,
       "taxable_amount": 37.93
-    },
-    "jurisdictions": {
-      "country": "US",
-      "state": "NY",
-      "county": "PUTNAM",
-      "city": "MAHOPAC"
     }
   }
 }
@@ -5107,6 +5110,12 @@ $ curl https://api.taxjar.com/v2/taxes \
     "has_nexus": true,
     "freight_taxable": false,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "US",
+      "state": "CA",
+      "county": "LOS ANGELES",
+      "city": "LOS ANGELES"
+    },
     "breakdown": {
       "city_tax_collectable": 0,
       "city_tax_rate": 0,
@@ -5161,12 +5170,6 @@ $ curl https://api.taxjar.com/v2/taxes \
       "state_taxable_amount": 0,
       "tax_collectable": 0,
       "taxable_amount": 0
-    },
-    "jurisdictions": {
-      "country": "US",
-      "state": "CA",
-      "county": "LOS ANGELES",
-      "city": "LOS ANGELES"
     }
   }
 }
@@ -5321,6 +5324,12 @@ $ curl https://api.taxjar.com/v2/taxes \
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "US",
+      "state": "WA",
+      "county": "SPOKANE",
+      "city": "SPOKANE"
+    },
     "breakdown": {
       "city_tax_collectable": 0.41,
       "city_tax_rate": 0.023,
@@ -5392,12 +5401,6 @@ $ curl https://api.taxjar.com/v2/taxes \
       "state_taxable_amount": 17.94,
       "tax_collectable": 1.58,
       "taxable_amount": 17.94
-    },
-    "jurisdictions": {
-      "country": "US",
-      "state": "WA",
-      "county": "SPOKANE",
-      "city": "SPOKANE"
     }
   }
 }

--- a/source/reference.md
+++ b/source/reference.md
@@ -5670,8 +5670,8 @@ rate | decimal | Overall sales tax rate of the order (`amount_to_collect` &divid
 has_nexus | bool | Whether or not you have [nexus](https://blog.taxjar.com/sales-tax-nexus-definition/) for the order based on an address on file, `nexus_addresses` parameter, or `from_` parameters.
 freight_taxable | bool | Freight taxability for the order.
 tax_source | string | [Origin-based or destination-based](https://blog.taxjar.com/charging-sales-tax-rates/) sales tax collection.
+jurisdictions | object | Jurisdiction names for the order.
 breakdown | object | Breakdown of rates by jurisdiction for the order, shipping, and individual line items. If `has_nexus` is false or no line items are provided, no breakdown is returned in the response.
-jurisdictions | object | Relevant jurisdictions.
 
 <h4 id="us-taxes-breakdown-attributes"><span class="flag-icon flag-icon-us"></span>&nbsp; United States Breakdown Attributes</h4>
 
@@ -5694,7 +5694,6 @@ special_tax_rate | decimal | Special district sales tax rate for given location.
 special_district_tax_collectable | decimal | Amount of sales tax to collect for the special district.
 shipping | object | Breakdown of shipping rates if applicable.
 line_items | object | Breakdown of rates by line item if applicable.
-jurisdictions | object | Relevant jurisdictions.
 
 <h4 id="canada-taxes-breakdown-attributes"><span class="flag-icon flag-icon-ca"></span>&nbsp; Canada Breakdown Attributes</h4>
 
@@ -5711,7 +5710,6 @@ qst_tax_rate | decimal | Quebec sales tax rate for given location.
 qst | decimal | Amount of Quebec sales tax to collect for given location.
 shipping | object | Breakdown of shipping rates if applicable.
 line_items | object | Breakdown of rates by line item if applicable.
-jurisdictions | object | Relevant jurisdictions.
 
 <h4 id="international-taxes-breakdown-attributes"><span class="flag-icon flag-icon-eu"></span> <span class="flag-icon flag-icon-au"></span>&nbsp; International Breakdown Attributes</h4>
 
@@ -5722,7 +5720,6 @@ country_tax_rate | decimal | Country sales tax rate for given location
 country_tax_collectable | decimal | Amount of sales tax to collect for the country.
 shipping | object | Breakdown of shipping rates if applicable.
 line_items | object | Breakdown of rates by line item if applicable.
-jurisdictions | object | Relevant jurisdictions.
 
 ## Transactions
 

--- a/source/reference.md
+++ b/source/reference.md
@@ -5673,6 +5673,29 @@ tax_source | string | [Origin-based or destination-based](https://blog.taxjar.co
 jurisdictions | object | Jurisdiction names for the order.
 breakdown | object | Breakdown of rates by jurisdiction for the order, shipping, and individual line items. If `has_nexus` is false or no line items are provided, no breakdown is returned in the response.
 
+<h4 id="us-taxes-jurisdiction-attributes"><span class="flag-icon flag-icon-us"></span>&nbsp; United States Jurisdiction Attributes</h4>
+
+Parameter | Type | Description
+--------- | ------- | -----------
+country | string | Two-letter ISO country code for given location.
+state | string | Postal abbreviated state name for given location.
+county | string | County name for given location.
+city | string | City name for given location.
+
+<h4 id="canada-taxes-jurisdiction-attributes"><span class="flag-icon flag-icon-ca"></span>&nbsp; Canada Jurisdiction Attributes</h4>
+
+Parameter | Type | Description
+--------- | ------- | -----------
+country | string | Two-letter ISO country code for given location.
+state | string | Postal abbreviated state name for given location.
+city | string | City name for given location.
+
+<h4 id="international-taxes-jurisdiction-attributes"><span class="flag-icon flag-icon-eu"></span> <span class="flag-icon flag-icon-au"></span>&nbsp; International Jurisdiction Attributes</h4>
+
+Parameter | Type | Description
+--------- | ------- | -----------
+country | string | Two-letter ISO country code for given location.
+
 <h4 id="us-taxes-breakdown-attributes"><span class="flag-icon flag-icon-us"></span>&nbsp; United States Breakdown Attributes</h4>
 
 Parameter | Type | Description


### PR DESCRIPTION
This PR adds the new `jurisdictions` object for /v2/taxes. Once the Ruby and Python API clients are released, update the response examples for those 2 languages.