### PR TITLE
added view note tool tip to to_street to explain rooftop accuracy

### DIFF
--- a/source/includes/endpoints/_taxes.md
+++ b/source/includes/endpoints/_taxes.md
@@ -4489,7 +4489,7 @@ to_country | string | required | Two-letter ISO country code of the country wher
 to_zip | string | <span class="conditional" data-tooltip="If `to_country` is 'US', `to_zip` is required." data-tooltip-position="top center">conditional</span> | Postal code where the order shipped to (5-Digit ZIP or ZIP+4).
 to_state | string | <span class="conditional" data-tooltip="If `to_country` is 'US' or 'CA', `to_state` is required." data-tooltip-position="top center">conditional</span> | Two-letter ISO state code where the order shipped to.
 to_city | string | optional | City where the order shipped to.
-to_street | string | optional | Street address where the order shipped to.
+to_street | string | optional | Street address where the order shipped to. <span class="usage-note" data-tooltip="Street address provides more accurate calculations for the following states: AR, AZ, CA, CO, CT, DC, FL, GA, HI, IA, ID, IN, KS, KY, LA, MA, MD, ME, MI, MN, MO, MS, NC, ND, NE, NJ, NM, NV, NY, OH, OK, PA, RI, SC, SD, TN, TX, UT, VA, VT, WA, WI, WV, WY" data-tooltip-position="top center">View Note</span>
 amount | decimal | optional | Total amount of the order, **excluding shipping**. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations." data-tooltip-position="top center">View Note</span>
 shipping | decimal | required | Total amount of shipping for the order.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.


### PR DESCRIPTION
@fastdivision, we should be having this note to let people know they should send in the to_street if they have it.  We have this for /v2/rates but not for /v2/taxes.

**Current /v2/rates**
<img width="691" alt="Screen Shot 2019-03-18 at 10 37 14 AM" src="https://user-images.githubusercontent.com/10674091/54542476-d8d8ee80-4969-11e9-94d3-99342a864fb0.png">

**Current /v2/taxes** (no note with tool tip)

<img width="599" alt="Screen Shot 2019-03-18 at 10 37 56 AM" src="https://user-images.githubusercontent.com/10674091/54542519-eaba9180-4969-11e9-9b55-5225c14600a9.png">


**Post Update:**

<img width="622" alt="Screen Shot 2019-03-18 at 10 36 01 AM" src="https://user-images.githubusercontent.com/10674091/54542365-b0e98b00-4969-11e9-8c00-7d2c7bb1e085.png">

<img width="660" alt="Screen Shot 2019-03-18 at 10 35 57 AM" src="https://user-images.githubusercontent.com/10674091/54542369-b2b34e80-4969-11e9-83d0-eaefb683c0bb.png">
