### PR TITLE
added a note to /v2/rates description to avoid confusion with taxes a…

### DIFF
--- a/source/includes/endpoints/_rates.md
+++ b/source/includes/endpoints/_rates.md
@@ -698,8 +698,8 @@ $ curl -G https://api.taxjar.com/v2/rates/00150 \
   'freight_taxable': True
 }>
 ```
-
-Shows the sales tax rates for a given location.
+Shows the sales tax rates for a given location.</br>
+*Please note that this only returns the full combined rate for a given location. During an actual sales tax calculation, you may see differences. Please use our <a href='https://developers.taxjar.com/api/reference/#post-calculate-sales-tax-for-an-order'>/v2/taxes endpoint </a> for actual calculations.*
 
 #### Request
 

--- a/source/includes/endpoints/_rates.md
+++ b/source/includes/endpoints/_rates.md
@@ -698,8 +698,9 @@ $ curl -G https://api.taxjar.com/v2/rates/00150 \
   'freight_taxable': True
 }>
 ```
-Shows the sales tax rates for a given location.</br>
-*Please note that this only returns the full combined rate for a given location. During an actual sales tax calculation, you may see differences. Please use our <a href='https://developers.taxjar.com/api/reference/#post-calculate-sales-tax-for-an-order'>/v2/taxes endpoint </a> for actual calculations.*
+Shows the sales tax rates for a given location.
+
+**Please note this endpoint only returns the full combined rate for a given location.** It does not support nexus determination, sourcing based on a ship from and ship to address, shipping taxability, product exemptions, customer exemptions, or sales tax holidays. We recommend using our [taxes endpoint](#post-calculate-sales-tax-for-an-order) to accurately calculate sales tax for an order.
 
 #### Request
 

--- a/source/includes/endpoints/_rates.md
+++ b/source/includes/endpoints/_rates.md
@@ -698,6 +698,7 @@ $ curl -G https://api.taxjar.com/v2/rates/00150 \
   'freight_taxable': True
 }>
 ```
+
 Shows the sales tax rates for a given location.
 
 **Please note this endpoint only returns the full combined rate for a given location.** It does not support nexus determination, sourcing based on a ship from and ship to address, shipping taxability, product exemptions, customer exemptions, or sales tax holidays. We recommend using our [taxes endpoint](#post-calculate-sales-tax-for-an-order) to accurately calculate sales tax for an order.

--- a/source/reference.md
+++ b/source/reference.md
@@ -23,10 +23,10 @@ includes:
   - countries
   - sales_tax_api
   - endpoints/categories
-  - endpoints/rates
   - endpoints/taxes
   - endpoints/transactions
   - endpoints/customers
+  - endpoints/rates
   - endpoints/nexus
   - endpoints/validations
   - endpoints/summarized_rates


### PR DESCRIPTION
…nd moved the docs around so rates is listed after the main endpoints

@fastdivision we have a lot of confusion with users going to /v2/rates before going to /v2/taxes so I thought we might want to look at moving /v2/rates lower in the docs.

<img width="238" alt="Screen Shot 2019-03-22 at 2 08 00 PM" src="https://user-images.githubusercontent.com/10674091/54847303-ff6d9100-4cab-11e9-86df-b339d3e1947c.png">

I also added a note in /v2/rates with a link to /v2/taxes to help point people in the right direction if they are looking for calcs

<img width="603" alt="Screen Shot 2019-03-22 at 2 08 08 PM" src="https://user-images.githubusercontent.com/10674091/54847335-0dbbad00-4cac-11e9-87ed-39027b52cafa.png">


Doesn't need to be exactly what I did or wrote, but I wanted to get the ball rolling