### PR TITLE
added info to the tooltip for taxes endpoint line_items id param

### DIFF
--- a/source/includes/endpoints/_taxes.md
+++ b/source/includes/endpoints/_taxes.md
@@ -4499,7 +4499,7 @@ nexus_addresses[][zip] | string | optional | Postal code for the nexus address.
 nexus_addresses[][state] | string | <span class="conditional" data-tooltip="If providing `nexus_addresses`, state is required." data-tooltip-position="top center">conditional</span> | Two-letter ISO state code for the nexus address.
 nexus_addresses[][city] | string | optional | City for the nexus address.
 nexus_addresses[][street] | string | optional | Street address for the nexus address.
-line_items[][id] | string | optional | Unique identifier of the given line item. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations." data-tooltip-position="top center">View Note</span>
+line_items[][id] | string | optional | Unique identifier of the given line item. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations. The ID needs to be unique to the line items in this order." data-tooltip-position="top center">View Note</span>
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_tax_code] | string | optional | Product tax code for the item. If omitted, the item will remain fully taxable.
 line_items[][unit_price] | decimal | optional | Unit price for the item.

--- a/source/includes/endpoints/_taxes.md
+++ b/source/includes/endpoints/_taxes.md
@@ -4499,7 +4499,7 @@ nexus_addresses[][zip] | string | optional | Postal code for the nexus address.
 nexus_addresses[][state] | string | <span class="conditional" data-tooltip="If providing `nexus_addresses`, state is required." data-tooltip-position="top center">conditional</span> | Two-letter ISO state code for the nexus address.
 nexus_addresses[][city] | string | optional | City for the nexus address.
 nexus_addresses[][street] | string | optional | Street address for the nexus address.
-line_items[][id] | string | optional | Unique identifier of the given line item. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations. The ID needs to be unique to the line_items in this order." data-tooltip-position="top center">View Note</span>
+line_items[][id] | string | optional | Unique identifier of the given line item. Duplicate item IDs within `line_items[]` will be ignored. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations." data-tooltip-position="top center">View Note</span>
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_tax_code] | string | optional | Product tax code for the item. If omitted, the item will remain fully taxable.
 line_items[][unit_price] | decimal | optional | Unit price for the item.

--- a/source/includes/endpoints/_taxes.md
+++ b/source/includes/endpoints/_taxes.md
@@ -4499,7 +4499,7 @@ nexus_addresses[][zip] | string | optional | Postal code for the nexus address.
 nexus_addresses[][state] | string | <span class="conditional" data-tooltip="If providing `nexus_addresses`, state is required." data-tooltip-position="top center">conditional</span> | Two-letter ISO state code for the nexus address.
 nexus_addresses[][city] | string | optional | City for the nexus address.
 nexus_addresses[][street] | string | optional | Street address for the nexus address.
-line_items[][id] | string | optional | Unique identifier of the given line item. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations. The ID needs to be unique to the line items in this order." data-tooltip-position="top center">View Note</span>
+line_items[][id] | string | optional | Unique identifier of the given line item. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations. The ID needs to be unique to the line_items in this order." data-tooltip-position="top center">View Note</span>
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_tax_code] | string | optional | Product tax code for the item. If omitted, the item will remain fully taxable.
 line_items[][unit_price] | decimal | optional | Unit price for the item.


### PR DESCRIPTION
We've had customer feedback a few times now that we should be more explicit that the line_items need to be unique in the /v2/taxes endpoint for that particular call.  I thought this addition to the tool tip would help.

<img width="526" alt="Screen Shot 2019-03-22 at 2 06 39 PM" src="https://user-images.githubusercontent.com/10674091/54847187-be757c80-4cab-11e9-97c6-17a04b8c733a.png">

