### PR TITLE
Update for Order-level Exemptions

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,6 +2,12 @@
 
 Stay on top of new developer-facing features, accuracy improvements, and bug fixes for our sales tax API. Have a request? Encounter an issue? [We'd love to hear your feedback.](mailto:support@taxjar.com)
 
+### June 2019
+
+#### 2019-06-26
+
+* <span class="badge badge--post">Feature</span> Order-level exemption support now available for transactions submitted through the API via new `exemption_type` param.
+
 ### March 2019
 
 #### 2019-03-28

--- a/source/includes/endpoints/_taxes.md
+++ b/source/includes/endpoints/_taxes.md
@@ -4493,6 +4493,7 @@ to_street | string | optional | Street address where the order shipped to. <span
 amount | decimal | optional | Total amount of the order, **excluding shipping**. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations." data-tooltip-position="top center">View Note</span>
 shipping | decimal | required | Total amount of shipping for the order.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
+exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 nexus_addresses[][id] | string | optional | Unique identifier of the given nexus address. <span class="usage-note" data-tooltip="Either an address on file, `nexus_addresses` parameter, or `from_` parameters are required to perform tax calculations." data-tooltip-position="top center">View Note</span>
 nexus_addresses[][country] | string | <span class="conditional" data-tooltip="If providing `nexus_addresses`, country is required." data-tooltip-position="top center">conditional</span> | Two-letter ISO country code for the nexus address.
 nexus_addresses[][zip] | string | optional | Postal code for the nexus address.
@@ -4531,6 +4532,7 @@ rate | decimal | Overall sales tax rate of the order (`amount_to_collect` &divid
 has_nexus | bool | Whether or not you have [nexus](https://blog.taxjar.com/sales-tax-nexus-definition/) for the order based on an address on file, `nexus_addresses` parameter, or `from_` parameters.
 freight_taxable | bool | Freight taxability for the order.
 tax_source | string | [Origin-based or destination-based](https://blog.taxjar.com/charging-sales-tax-rates/) sales tax collection.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 jurisdictions | object | Jurisdiction names for the order.
 breakdown | object | Breakdown of rates by jurisdiction for the order, shipping, and individual line items. If `has_nexus` is false or no line items are provided, no breakdown is returned in the response.
 

--- a/source/includes/endpoints/_taxes.md
+++ b/source/includes/endpoints/_taxes.md
@@ -4532,7 +4532,7 @@ rate | decimal | Overall sales tax rate of the order (`amount_to_collect` &divid
 has_nexus | bool | Whether or not you have [nexus](https://blog.taxjar.com/sales-tax-nexus-definition/) for the order based on an address on file, `nexus_addresses` parameter, or `from_` parameters.
 freight_taxable | bool | Freight taxability for the order.
 tax_source | string | [Origin-based or destination-based](https://blog.taxjar.com/charging-sales-tax-rates/) sales tax collection.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. If no `customer_id` or `exemption_type` is provided, no `exemption_type` is returned in the response.
 jurisdictions | object | Jurisdiction names for the order.
 breakdown | object | Breakdown of rates by jurisdiction for the order, shipping, and individual line items. If `has_nexus` is false or no line items are provided, no breakdown is returned in the response.
 

--- a/source/includes/endpoints/_transactions.md
+++ b/source/includes/endpoints/_transactions.md
@@ -391,6 +391,7 @@ transaction_id | string | Unique identifier of the given order transaction.
 user_id | integer | Unique identifier of the user who created the order transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -786,6 +787,7 @@ amount | decimal | required | Total amount of the order with shipping, **excludi
 shipping | decimal | required | Total amount of shipping for the order in dollars.
 sales_tax | decimal | required | Total amount of sales tax collected for the order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
+exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 line_items[][id] | string | optional | Unique identifier of the given line item.
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
@@ -815,6 +817,7 @@ transaction_id | string | Unique identifier of the given order transaction.
 user_id | integer | Unique identifier of the user who created the order transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -1170,6 +1173,7 @@ amount | decimal | optional | Total amount of the order with shipping, **excludi
 shipping | decimal | optional | Total amount of shipping for the order in dollars.
 sales_tax | decimal | optional | Total amount of sales tax collected for the order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
+exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 line_items[][id] | string | optional | Unique identifier of the given line item.
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
@@ -1197,6 +1201,7 @@ transaction_id | string | Unique identifier of the given order transaction.
 user_id | integer | Unique identifier of the user who created the order transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -1809,6 +1814,7 @@ transaction_id | string | Unique identifier of the given refund transaction.
 user_id | integer | Unique identifier of the user who created the refund transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -2218,6 +2224,7 @@ amount | decimal | required | Total amount of the refunded order with shipping, 
 shipping | decimal | required | Total amount of shipping for the refunded order in dollars.
 sales_tax | decimal | required | Total amount of sales tax collected for the refunded order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
+exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 line_items[][id] | string | optional | Unique identifier of the given line item.
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
@@ -2247,6 +2254,7 @@ transaction_id | string | Unique identifier of the given refund transaction.
 user_id | integer | Unique identifier of the user who created the refund transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -2603,6 +2611,7 @@ amount | decimal | optional | Total amount of the refunded order with shipping, 
 shipping | decimal | optional | Total amount of shipping for the refunded order in dollars.
 sales_tax | decimal | optional | Total amount of sales tax collected for the refunded order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
+exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 line_items[][id] | string | optional | Unique identifier of the given line item.
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
@@ -2630,6 +2639,7 @@ transaction_id | string | Unique identifier of the given refund transaction.
 user_id | integer | Unique identifier of the user who created the refund transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.

--- a/source/includes/endpoints/_transactions.md
+++ b/source/includes/endpoints/_transactions.md
@@ -391,7 +391,7 @@ transaction_id | string | Unique identifier of the given order transaction.
 user_id | integer | Unique identifier of the user who created the order transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -817,7 +817,7 @@ transaction_id | string | Unique identifier of the given order transaction.
 user_id | integer | Unique identifier of the user who created the order transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -1201,7 +1201,7 @@ transaction_id | string | Unique identifier of the given order transaction.
 user_id | integer | Unique identifier of the user who created the order transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -1814,7 +1814,7 @@ transaction_id | string | Unique identifier of the given refund transaction.
 user_id | integer | Unique identifier of the user who created the refund transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -2254,7 +2254,7 @@ transaction_id | string | Unique identifier of the given refund transaction.
 user_id | integer | Unique identifier of the user who created the refund transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -2639,7 +2639,7 @@ transaction_id | string | Unique identifier of the given refund transaction.
 user_id | integer | Unique identifier of the user who created the refund transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.


### PR DESCRIPTION
This PR adds the `exemption_type` param to support order-level exemptions in the following endpoints:

- POST **v2/taxes**
- POST **v2/transactions/orders**
- PUT **v2/transactions/orders/:transaction_id**
- POST **v2/transactions/refunds**
- PUT **v2/transactions/refunds/:transaction_id**