### PR TITLE
Update all `decimal` types to `float`

### DIFF
--- a/source/includes/endpoints/_rates.md
+++ b/source/includes/endpoints/_rates.md
@@ -727,15 +727,15 @@ Parameter | Type | Description
 --------- | ------- | -----------
 zip | string | Postal code for given location.
 country | string | Country for given location if SST state. <span class="usage-note" data-tooltip="Streamlined sales tax project member states include: AR, GA, IN, IA, KS, KY, MI, MN, NE, NV, NJ, NC, ND, OK, RI, SD, UT, VT, WA, WV, WI, WY" data-tooltip-position="top center">View Note</span>
-country_rate | decimal | Country sales tax rate for given location if SST state. <span class="usage-note" data-tooltip="Streamlined sales tax project member states include: AR, GA, IN, IA, KS, KY, MI, MN, NE, NV, NJ, NC, ND, OK, RI, SD, UT, VT, WA, WV, WI, WY" data-tooltip-position="top center">View Note</span>
+country_rate | float | Country sales tax rate for given location if SST state. <span class="usage-note" data-tooltip="Streamlined sales tax project member states include: AR, GA, IN, IA, KS, KY, MI, MN, NE, NV, NJ, NC, ND, OK, RI, SD, UT, VT, WA, WV, WI, WY" data-tooltip-position="top center">View Note</span>
 state | string | Postal abbreviated state name for given location.
-state_rate | decimal | State sales tax rate for given location.
+state_rate | float | State sales tax rate for given location.
 county | string | County name for given location.
-county_rate | decimal | County sales tax rate for given location.
+county_rate | float | County sales tax rate for given location.
 city | string | City name for given location.
-city_rate | decimal | City sales tax rate for given location.
-combined_district_rate | decimal | Aggregate rate for all city and county sales tax districts effective at the location.
-combined_rate | decimal | Overall sales tax rate which includes state, county, city and district tax. This rate should be used to determine how much sales tax to collect for an order.
+city_rate | float | City sales tax rate for given location.
+combined_district_rate | float | Aggregate rate for all city and county sales tax districts effective at the location.
+combined_rate | float | Overall sales tax rate which includes state, county, city and district tax. This rate should be used to determine how much sales tax to collect for an order.
 freight_taxable | bool | Freight taxability for given location.
 
 <h4 id="ca-rate-attributes"><span class="flag-icon flag-icon-ca"></span>&nbsp; Canada Attributes</h4>
@@ -746,7 +746,7 @@ zip | string | Postal code for given location.
 city | string | City name for given location.
 state | string | Postal abbreviated state name for given location.
 country | string | Two-letter ISO country code for given location.
-combined_rate | decimal | Overall sales tax rate. This rate should be used to determine how much sales tax to collect for an order.
+combined_rate | float | Overall sales tax rate. This rate should be used to determine how much sales tax to collect for an order.
 freight_taxable | bool | Freight taxability for given location.
 
 <h4 id="au-rate-attributes"><span class="flag-icon flag-icon-au"></span>&nbsp; Australia Attributes</h4>
@@ -755,8 +755,8 @@ Parameter | Type | Description
 --------- | ------- | -----------
 zip | string | Postal code for given location.
 country | string | Two-letter ISO country code for given location.
-country_rate | decimal | Country sales tax rate for given location.
-combined_rate | decimal | Overall sales tax rate. This rate should be used to determine how much sales tax to collect for an order.
+country_rate | float | Country sales tax rate for given location.
+combined_rate | float | Overall sales tax rate. This rate should be used to determine how much sales tax to collect for an order.
 freight_taxable | bool | Freight taxability for given location.
 
 <h4 id="eu-rate-attributes"><span class="flag-icon flag-icon-eu"></span>&nbsp; European Union Attributes</h4>
@@ -765,9 +765,9 @@ Parameter | Type | Description
 --------- | ------- | -----------
 country | string | Two-letter ISO country code for given location.
 name | string | Country name for given location.
-standard_rate | decimal | [Standard rate](https://en.wikipedia.org/wiki/European_Union_value_added_tax#VAT_rates) for given location.
-reduced_rate | decimal | [Reduced rate](https://en.wikipedia.org/wiki/European_Union_value_added_tax#VAT_rates) for given location.
-super_reduced_rate | decimal | Super reduced rate for given location.
-parking_rate | decimal | Parking rate for given location.
-distance_sale_threshold | decimal | [Distance selling threshold](https://en.wikipedia.org/wiki/European_Union_value_added_tax#Distance_sales) for given location.
+standard_rate | float | [Standard rate](https://en.wikipedia.org/wiki/European_Union_value_added_tax#VAT_rates) for given location.
+reduced_rate | float | [Reduced rate](https://en.wikipedia.org/wiki/European_Union_value_added_tax#VAT_rates) for given location.
+super_reduced_rate | float | Super reduced rate for given location.
+parking_rate | float | Parking rate for given location.
+distance_sale_threshold | float | [Distance selling threshold](https://en.wikipedia.org/wiki/European_Union_value_added_tax#Distance_sales) for given location.
 freight_taxable | bool | Freight taxability for given location.

--- a/source/includes/endpoints/_taxes.md
+++ b/source/includes/endpoints/_taxes.md
@@ -4258,8 +4258,8 @@ to_zip | string | <span class="conditional" data-tooltip="If `to_country` is 'US
 to_state | string | <span class="conditional" data-tooltip="If `to_country` is 'US' or 'CA', `to_state` is required." data-tooltip-position="top center">conditional</span> | Two-letter ISO state code where the order shipped to.
 to_city | string | optional | City where the order shipped to.
 to_street | string | optional | Street address where the order shipped to. <span class="usage-note" data-tooltip="Street address provides more accurate calculations for the following states: AR, AZ, CA, CO, CT, DC, FL, GA, HI, IA, ID, IN, KS, KY, LA, MA, MD, ME, MI, MN, MO, MS, NC, ND, NE, NJ, NM, NV, NY, OH, OK, PA, RI, SC, SD, TN, TX, UT, VA, VT, WA, WI, WV, WY" data-tooltip-position="top center">View Note</span>
-amount | decimal | optional | Total amount of the order, **excluding shipping**. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations." data-tooltip-position="top center">View Note</span>
-shipping | decimal | required | Total amount of shipping for the order.
+amount | float | optional | Total amount of the order, **excluding shipping**. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations." data-tooltip-position="top center">View Note</span>
+shipping | float | required | Total amount of shipping for the order.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
 exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 nexus_addresses[][id] | string | optional | Unique identifier of the given nexus address. <span class="usage-note" data-tooltip="Either an address on file, `nexus_addresses` parameter, or `from_` parameters are required to perform tax calculations." data-tooltip-position="top center">View Note</span>
@@ -4271,8 +4271,8 @@ nexus_addresses[][street] | string | optional | Street address for the nexus add
 line_items[][id] | string | optional | Unique identifier of the given line item. Duplicate item IDs within `line_items[]` will be ignored. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations." data-tooltip-position="top center">View Note</span>
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_tax_code] | string | optional | Product tax code for the item. If omitted, the item will remain fully taxable.
-line_items[][unit_price] | decimal | optional | Unit price for the item.
-line_items[][discount] | decimal | optional | Total discount (non-unit) for the item.
+line_items[][unit_price] | float | optional | Unit price for the item.
+line_items[][discount] | float | optional | Total discount (non-unit) for the item.
 
 #### Notes
 
@@ -4292,11 +4292,11 @@ Returns a `tax` JSON object with sales tax for a given order. If available, retu
 
 Parameter | Type | Description
 --------- | ------- | -----------
-order_total_amount | decimal | Total amount of the order.
-shipping | decimal | Total amount of shipping for the order.
-taxable_amount | decimal | Amount of the order to be taxed.
-amount_to_collect | decimal | Amount of sales tax to collect.
-rate | decimal | Overall sales tax rate of the order (`amount_to_collect` &divide; `taxable_amount`).
+order_total_amount | float | Total amount of the order.
+shipping | float | Total amount of shipping for the order.
+taxable_amount | float | Amount of the order to be taxed.
+amount_to_collect | float | Amount of sales tax to collect.
+rate | float | Overall sales tax rate of the order (`amount_to_collect` &divide; `taxable_amount`).
 has_nexus | bool | Whether or not you have [nexus](https://blog.taxjar.com/sales-tax-nexus-definition/) for the order based on an address on file, `nexus_addresses` parameter, or `from_` parameters.
 freight_taxable | bool | Freight taxability for the order.
 tax_source | string | [Origin-based or destination-based](https://blog.taxjar.com/charging-sales-tax-rates/) sales tax collection.
@@ -4338,21 +4338,21 @@ city | string | City name for given location.
 
 Parameter | Type | Description
 --------- | ------- | -----------
-taxable_amount | decimal | Total amount of the order to be taxed.
-tax_collectable | decimal | Total amount of sales tax to collect.
-combined_tax_rate | decimal | Overall sales tax rate of the breakdown which includes state, county, city and district tax for the order and shipping if applicable.
-state_taxable_amount | decimal | Amount of the order to be taxed at the state tax rate.
-state_tax_rate | decimal | State sales tax rate for given location.
-state_tax_collectable | decimal | Amount of sales tax to collect for the state.
-county_taxable_amount | decimal | Amount of the order to be taxed at the county tax rate.
-county_tax_rate | decimal | County sales tax rate for given location.
-county_tax_collectable | decimal | Amount of sales tax to collect for the county.
-city_taxable_amount | decimal | Amount of the order to be taxed at the city tax rate.
-city_tax_rate | decimal | City sales tax rate for given location.
-city_tax_collectable | decimal | Amount of sales tax to collect for the city.
-special_district_taxable_amount | decimal | Amount of the order to be taxed at the special district tax rate.
-special_tax_rate | decimal | Special district sales tax rate for given location.
-special_district_tax_collectable | decimal | Amount of sales tax to collect for the special district.
+taxable_amount | float | Total amount of the order to be taxed.
+tax_collectable | float | Total amount of sales tax to collect.
+combined_tax_rate | float | Overall sales tax rate of the breakdown which includes state, county, city and district tax for the order and shipping if applicable.
+state_taxable_amount | float | Amount of the order to be taxed at the state tax rate.
+state_tax_rate | float | State sales tax rate for given location.
+state_tax_collectable | float | Amount of sales tax to collect for the state.
+county_taxable_amount | float | Amount of the order to be taxed at the county tax rate.
+county_tax_rate | float | County sales tax rate for given location.
+county_tax_collectable | float | Amount of sales tax to collect for the county.
+city_taxable_amount | float | Amount of the order to be taxed at the city tax rate.
+city_tax_rate | float | City sales tax rate for given location.
+city_tax_collectable | float | Amount of sales tax to collect for the city.
+special_district_taxable_amount | float | Amount of the order to be taxed at the special district tax rate.
+special_tax_rate | float | Special district sales tax rate for given location.
+special_district_tax_collectable | float | Amount of sales tax to collect for the special district.
 shipping | object | Breakdown of shipping rates if applicable.
 line_items | object | Breakdown of rates by line item if applicable.
 
@@ -4360,15 +4360,15 @@ line_items | object | Breakdown of rates by line item if applicable.
 
 Parameter | Type | Description
 --------- | ------- | -----------
-gst_taxable_amount | decimal | Amount of the order to be taxed at the GST rate.
-gst_tax_rate | decimal | Goods and services tax rate for given location.
-gst | decimal | Amount of goods and services tax to collect for given location.
-pst_taxable_amount | decimal | Amount of the order to be taxed at the PST rate.
-pst_tax_rate | decimal | Provincial sales tax rate for given location.
-pst | decimal | Amount of provincial sales tax to collect for given location.
-qst_taxable_amount | decimal | Amount of the order to be taxed at the QST rate.
-qst_tax_rate | decimal | Quebec sales tax rate for given location.
-qst | decimal | Amount of Quebec sales tax to collect for given location.
+gst_taxable_amount | float | Amount of the order to be taxed at the GST rate.
+gst_tax_rate | float | Goods and services tax rate for given location.
+gst | float | Amount of goods and services tax to collect for given location.
+pst_taxable_amount | float | Amount of the order to be taxed at the PST rate.
+pst_tax_rate | float | Provincial sales tax rate for given location.
+pst | float | Amount of provincial sales tax to collect for given location.
+qst_taxable_amount | float | Amount of the order to be taxed at the QST rate.
+qst_tax_rate | float | Quebec sales tax rate for given location.
+qst | float | Amount of Quebec sales tax to collect for given location.
 shipping | object | Breakdown of shipping rates if applicable.
 line_items | object | Breakdown of rates by line item if applicable.
 
@@ -4376,8 +4376,8 @@ line_items | object | Breakdown of rates by line item if applicable.
 
 Parameter | Type | Description
 --------- | ------- | -----------
-country_taxable_amount | decimal | Amount of the order to be taxed at the country tax rate.
-country_tax_rate | decimal | Country sales tax rate for given location
-country_tax_collectable | decimal | Amount of sales tax to collect for the country.
+country_taxable_amount | float | Amount of the order to be taxed at the country tax rate.
+country_tax_rate | float | Country sales tax rate for given location
+country_tax_collectable | float | Amount of sales tax to collect for the country.
 shipping | object | Breakdown of shipping rates if applicable.
 line_items | object | Breakdown of rates by line item if applicable.

--- a/source/includes/endpoints/_transactions.md
+++ b/source/includes/endpoints/_transactions.md
@@ -402,17 +402,17 @@ to_zip | string | Postal code where the order shipped to (5-Digit ZIP or ZIP+4).
 to_state | string | Two-letter ISO state code where the order shipped to.
 to_city | string | City where the order shipped to.
 to_street | string | Street address where the order shipped to.
-amount | decimal | Total amount of the order with shipping, **excluding sales tax**.
-shipping | decimal | Total amount of shipping for the order.
-sales_tax | decimal | Total amount of sales tax collected for the order.
+amount | float | Total amount of the order with shipping, **excluding sales tax**.
+shipping | float | Total amount of shipping for the order.
+sales_tax | float | Total amount of sales tax collected for the order.
 line_items[][id] | string | Unique identifier of the given line item.
 line_items[][quantity] | integer | Quantity for the item.
 line_items[][product_identifier] | string | Product identifier for the item.
 line_items[][description] | string  | Description of the line item (up to 255 characters).
 line_items[][product_tax_code] | string | Product tax code for the item.
-line_items[][unit_price] | decimal | Unit price for the item in dollars.
-line_items[][discount] | decimal | Total discount (non-unit) for the item in dollars.
-line_items[][sales_tax] | decimal | Total sales tax collected (non-unit) for the item in dollars.
+line_items[][unit_price] | float | Unit price for the item in dollars.
+line_items[][discount] | float | Total discount (non-unit) for the item in dollars.
+line_items[][sales_tax] | float | Total sales tax collected (non-unit) for the item in dollars.
 
 ### <span class="badge badge--post">post</span> Create an order transaction
 
@@ -783,9 +783,9 @@ to_zip | string | required | Postal code where the order shipped to (5-Digit ZIP
 to_state | string | required | Two-letter ISO state code where the order shipped to.
 to_city | string | optional | City where the order shipped to.
 to_street | string | optional | Street address where the order shipped to.
-amount | decimal | required | Total amount of the order with shipping, **excluding sales tax** in dollars.
-shipping | decimal | required | Total amount of shipping for the order in dollars.
-sales_tax | decimal | required | Total amount of sales tax collected for the order in dollars.
+amount | float | required | Total amount of the order with shipping, **excluding sales tax** in dollars.
+shipping | float | required | Total amount of shipping for the order in dollars.
+sales_tax | float | required | Total amount of sales tax collected for the order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
 exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 line_items[][id] | string | optional | Unique identifier of the given line item.
@@ -793,9 +793,9 @@ line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
 line_items[][description] | string | optional | Description of the line item (up to 255 characters).
 line_items[][product_tax_code] | string | optional | Product tax code for the item. If omitted, the item will remain fully taxable.
-line_items[][unit_price] | decimal | optional | Unit price for the item in dollars.
-line_items[][discount] | decimal | optional | Total discount (non-unit) for the item in dollars.
-line_items[][sales_tax] | decimal | <span class="conditional" data-tooltip="If providing `line_items`, `sales_tax` is required." data-tooltip-position="top center">conditional</span> | Total sales tax collected (non-unit) for the item in dollars.
+line_items[][unit_price] | float | optional | Unit price for the item in dollars.
+line_items[][discount] | float | optional | Total discount (non-unit) for the item in dollars.
+line_items[][sales_tax] | float | <span class="conditional" data-tooltip="If providing `line_items`, `sales_tax` is required." data-tooltip-position="top center">conditional</span> | Total sales tax collected (non-unit) for the item in dollars.
 
 #### Notes
 
@@ -828,17 +828,17 @@ to_zip | string | Postal code where the order shipped to (5-Digit ZIP or ZIP+4).
 to_state | string | Two-letter ISO state code where the order shipped to.
 to_city | string | City where the order shipped to.
 to_street | string | Street address where the order shipped to.
-amount | decimal | Total amount of the order with shipping, **excluding sales tax**.
-shipping | decimal | Total amount of shipping for the order.
-sales_tax | decimal | Total amount of sales tax collected for the order.
+amount | float | Total amount of the order with shipping, **excluding sales tax**.
+shipping | float | Total amount of shipping for the order.
+sales_tax | float | Total amount of sales tax collected for the order.
 line_items[][id] | string | Unique identifier of the given line item.
 line_items[][quantity] | integer | Quantity for the item.
 line_items[][product_identifier] | string | Product identifier for the item.
 line_items[][description] | string  | Description of the line item (up to 255 characters).
 line_items[][product_tax_code] | string | Product tax code for the item.
-line_items[][unit_price] | decimal | Unit price for the item in dollars.
-line_items[][discount] | decimal | Total discount (non-unit) for the item in dollars.
-line_items[][sales_tax] | decimal | Total sales tax collected (non-unit) for the item in dollars.
+line_items[][unit_price] | float | Unit price for the item in dollars.
+line_items[][discount] | float | Total discount (non-unit) for the item in dollars.
+line_items[][sales_tax] | float | Total sales tax collected (non-unit) for the item in dollars.
 
 ### <span class="badge badge--put">put</span> Update an order transaction
 
@@ -1169,9 +1169,9 @@ to_zip | string | optional | Postal code where the order shipped to (5-Digit ZIP
 to_state | string | optional | Two-letter ISO state code where the order shipped to.
 to_city | string | optional | City where the order shipped to.
 to_street | string | optional | Street address where the order shipped to.
-amount | decimal | optional | Total amount of the order with shipping, **excluding sales tax** in dollars.
-shipping | decimal | optional | Total amount of shipping for the order in dollars.
-sales_tax | decimal | optional | Total amount of sales tax collected for the order in dollars.
+amount | float | optional | Total amount of the order with shipping, **excluding sales tax** in dollars.
+shipping | float | optional | Total amount of shipping for the order in dollars.
+sales_tax | float | optional | Total amount of sales tax collected for the order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
 exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 line_items[][id] | string | optional | Unique identifier of the given line item.
@@ -1179,9 +1179,9 @@ line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
 line_items[][description] | string | optional | Description of the line item (up to 255 characters).
 line_items[][product_tax_code] | string | optional | Product tax code for the item. If omitted, the item will remain fully taxable.
-line_items[][unit_price] | decimal | optional | Unit price for the item in dollars.
-line_items[][discount] | decimal | optional | Total discount (non-unit) for the item in dollars.
-line_items[][sales_tax] | decimal | optional | Total sales tax collected (non-unit) for the item in dollars.
+line_items[][unit_price] | float | optional | Unit price for the item in dollars.
+line_items[][discount] | float | optional | Total discount (non-unit) for the item in dollars.
+line_items[][sales_tax] | float | optional | Total sales tax collected (non-unit) for the item in dollars.
 
 #### Notes
 
@@ -1212,17 +1212,17 @@ to_zip | string | Postal code where the order shipped to (5-Digit ZIP or ZIP+4).
 to_state | string | Two-letter ISO state code where the order shipped to.
 to_city | string | City where the order shipped to.
 to_street | string | Street address where the order shipped to.
-amount | decimal | Total amount of the order with shipping, **excluding sales tax**.
-shipping | decimal | Total amount of shipping for the order.
-sales_tax | decimal | Total amount of sales tax collected for the order.
+amount | float | Total amount of the order with shipping, **excluding sales tax**.
+shipping | float | Total amount of shipping for the order.
+sales_tax | float | Total amount of sales tax collected for the order.
 line_items[][id] | string | Unique identifier of the given line item.
 line_items[][quantity] | integer | Quantity for the item.
 line_items[][product_identifier] | string | Product identifier for the item.
 line_items[][description] | string  | Description of the line item (up to 255 characters).
 line_items[][product_tax_code] | string | Product tax code for the item.
-line_items[][unit_price] | decimal | Unit price for the item in dollars.
-line_items[][discount] | decimal | Total discount (non-unit) for the item in dollars.
-line_items[][sales_tax] | decimal | Total sales tax collected (non-unit) for the item in dollars.
+line_items[][unit_price] | float | Unit price for the item in dollars.
+line_items[][discount] | float | Total discount (non-unit) for the item in dollars.
+line_items[][sales_tax] | float | Total sales tax collected (non-unit) for the item in dollars.
 
 ### <span class="badge badge--delete">delete</span> Delete an order transaction
 
@@ -1825,17 +1825,17 @@ to_zip | string | Postal code where the order shipped to (5-Digit ZIP or ZIP+4).
 to_state | string | Two-letter ISO state code where the order shipped to.
 to_city | string | City where the order shipped to.
 to_street | string | Street address where the order shipped to.
-amount | decimal | Total amount of the refunded order with shipping, **excluding sales tax**.
-shipping | decimal | Total amount of shipping for the refunded order.
-sales_tax | decimal | Total amount of sales tax collected for the refunded order.
+amount | float | Total amount of the refunded order with shipping, **excluding sales tax**.
+shipping | float | Total amount of shipping for the refunded order.
+sales_tax | float | Total amount of sales tax collected for the refunded order.
 line_items[][id] | string | Unique identifier of the given line item.
 line_items[][quantity] | integer | Quantity for the item.
 line_items[][product_identifier] | string | Product identifier for the item.
 line_items[][description] | string  | Description of the line item (up to 255 characters).
 line_items[][product_tax_code] | string | Product tax code for the item.
-line_items[][unit_price] | decimal | Unit price for the item in dollars.
-line_items[][discount] | decimal | Total discount (non-unit) for the item in dollars.
-line_items[][sales_tax] | decimal | Total sales tax collected (non-unit) for the item in dollars.
+line_items[][unit_price] | float | Unit price for the item in dollars.
+line_items[][discount] | float | Total discount (non-unit) for the item in dollars.
+line_items[][sales_tax] | float | Total sales tax collected (non-unit) for the item in dollars.
 
 ### <span class="badge badge--post">post</span> Create a refund transaction
 
@@ -2220,9 +2220,9 @@ to_zip | string | required | Postal code where the order shipped to (5-Digit ZIP
 to_state | string | required | Two-letter ISO state code where the order shipped to.
 to_city | string | optional | City where the order shipped to.
 to_street | string | optional | Street address where the order shipped to.
-amount | decimal | required | Total amount of the refunded order with shipping, **excluding sales tax** in dollars.
-shipping | decimal | required | Total amount of shipping for the refunded order in dollars.
-sales_tax | decimal | required | Total amount of sales tax collected for the refunded order in dollars.
+amount | float | required | Total amount of the refunded order with shipping, **excluding sales tax** in dollars.
+shipping | float | required | Total amount of shipping for the refunded order in dollars.
+sales_tax | float | required | Total amount of sales tax collected for the refunded order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
 exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 line_items[][id] | string | optional | Unique identifier of the given line item.
@@ -2230,9 +2230,9 @@ line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
 line_items[][description] | string | optional | Description of the line item (up to 255 characters).
 line_items[][product_tax_code] | string | optional | Product tax code for the item. If omitted, the item will remain fully taxable.
-line_items[][unit_price] | decimal | optional | Unit price for the item in dollars.
-line_items[][discount] | decimal | optional | Total discount (non-unit) for the item in dollars.
-line_items[][sales_tax] | decimal | <span class="conditional" data-tooltip="If providing `line_items`, `sales_tax` is required." data-tooltip-position="top center">conditional</span> | Total sales tax collected (non-unit) for the item in dollars.
+line_items[][unit_price] | float | optional | Unit price for the item in dollars.
+line_items[][discount] | float | optional | Total discount (non-unit) for the item in dollars.
+line_items[][sales_tax] | float | <span class="conditional" data-tooltip="If providing `line_items`, `sales_tax` is required." data-tooltip-position="top center">conditional</span> | Total sales tax collected (non-unit) for the item in dollars.
 
 #### Notes
 
@@ -2265,17 +2265,17 @@ to_zip | string | Postal code where the order shipped to (5-Digit ZIP or ZIP+4).
 to_state | string | Two-letter ISO state code where the order shipped to.
 to_city | string | City where the order shipped to.
 to_street | string | Street address where the order shipped to.
-amount | decimal | Total amount of the refunded order with shipping, **excluding sales tax**.
-shipping | decimal | Total amount of shipping for the refunded order.
-sales_tax | decimal | Total amount of sales tax collected for the refunded order.
+amount | float | Total amount of the refunded order with shipping, **excluding sales tax**.
+shipping | float | Total amount of shipping for the refunded order.
+sales_tax | float | Total amount of sales tax collected for the refunded order.
 line_items[][id] | string | Unique identifier of the given line item.
 line_items[][quantity] | integer | Quantity for the item.
 line_items[][product_identifier] | string | Product identifier for the item.
 line_items[][description] | string  | Description of the line item (up to 255 characters).
 line_items[][product_tax_code] | string | Product tax code for the item.
-line_items[][unit_price] | decimal | Unit price for the item in dollars.
-line_items[][discount] | decimal | Total discount (non-unit) for the item in dollars.
-line_items[][sales_tax] | decimal | Total sales tax collected (non-unit) for the item in dollars.
+line_items[][unit_price] | float | Unit price for the item in dollars.
+line_items[][discount] | float | Total discount (non-unit) for the item in dollars.
+line_items[][sales_tax] | float | Total sales tax collected (non-unit) for the item in dollars.
 
 ### <span class="badge badge--put">put</span> Update a refund transaction
 
@@ -2607,9 +2607,9 @@ to_zip | string | optional | Postal code where the refunded order shipped to (5-
 to_state | string | optional | Two-letter ISO state code where the refunded order shipped to.
 to_city | string | optional | City where the refunded order shipped to.
 to_street | string | optional | Street address where the refunded order shipped to.
-amount | decimal | optional | Total amount of the refunded order with shipping, **excluding sales tax** in dollars.
-shipping | decimal | optional | Total amount of shipping for the refunded order in dollars.
-sales_tax | decimal | optional | Total amount of sales tax collected for the refunded order in dollars.
+amount | float | optional | Total amount of the refunded order with shipping, **excluding sales tax** in dollars.
+shipping | float | optional | Total amount of shipping for the refunded order in dollars.
+sales_tax | float | optional | Total amount of sales tax collected for the refunded order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
 exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
 line_items[][id] | string | optional | Unique identifier of the given line item.
@@ -2617,9 +2617,9 @@ line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
 line_items[][description] | string | optional | Description of the line item (up to 255 characters).
 line_items[][product_tax_code] | string | optional | Product tax code for the item. If omitted, the item will remain fully taxable.
-line_items[][unit_price] | decimal | optional | Unit price for the item in dollars.
-line_items[][discount] | decimal | optional | Total discount (non-unit) for the item in dollars.
-line_items[][sales_tax] | decimal | optional | Total sales tax collected (non-unit) for the item in dollars.
+line_items[][unit_price] | float | optional | Unit price for the item in dollars.
+line_items[][discount] | float | optional | Total discount (non-unit) for the item in dollars.
+line_items[][sales_tax] | float | optional | Total sales tax collected (non-unit) for the item in dollars.
 
 #### Notes
 
@@ -2650,17 +2650,17 @@ to_zip | string | Postal code where the order shipped to (5-Digit ZIP or ZIP+4).
 to_state | string | Two-letter ISO state code where the order shipped to.
 to_city | string | City where the order shipped to.
 to_street | string | Street address where the order shipped to.
-amount | decimal | Total amount of the refunded order with shipping, **excluding sales tax**.
-shipping | decimal | Total amount of shipping for the refunded order.
-sales_tax | decimal | Total amount of sales tax collected for the refunded order.
+amount | float | Total amount of the refunded order with shipping, **excluding sales tax**.
+shipping | float | Total amount of shipping for the refunded order.
+sales_tax | float | Total amount of sales tax collected for the refunded order.
 line_items[][id] | string | Unique identifier of the given line item.
 line_items[][quantity] | integer | Quantity for the item.
 line_items[][product_identifier] | string | Product identifier for the item.
 line_items[][description] | string  | Description of the line item (up to 255 characters).
 line_items[][product_tax_code] | string | Product tax code for the item.
-line_items[][unit_price] | decimal | Unit price for the item in dollars.
-line_items[][discount] | decimal | Total discount (non-unit) for the item in dollars.
-line_items[][sales_tax] | decimal | Total sales tax collected (non-unit) for the item in dollars.
+line_items[][unit_price] | float | Unit price for the item in dollars.
+line_items[][discount] | float | Total discount (non-unit) for the item in dollars.
+line_items[][sales_tax] | float | Total sales tax collected (non-unit) for the item in dollars.
 
 ### <span class="badge badge--delete">delete</span> Delete a refund transaction
 

--- a/source/javascripts/app/popover.js
+++ b/source/javascripts/app/popover.js
@@ -13,7 +13,7 @@
         });
       });
 
-      $('h4[id="parameters"] + table td:contains("decimal")').each(function() {
+      $('h4[id="parameters"] + table td:contains("float")').each(function() {
         $(this).html('<span class="type-hint">' + $(this).text() + '</span>');
         new Drop({
           target: $(this).find('> span').get(0),


### PR DESCRIPTION
To reduce confusion around the type returned from the TaxJar SmartCalcs API for monetary values, we are switching from documenting the type as `decimal` to `float`.

Note: No actual change has been made to our API. This is just to make the documentation more specific.

<sub>_(Yes, we are aware that, technically, JSON does not specify a number type.)_</sub>