### PR TITLE
Note that `exemption_type` param now accepts `marketplace`

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,6 +2,12 @@
 
 Stay on top of new developer-facing features, accuracy improvements, and bug fixes for our sales tax API. Have a request? Encounter an issue? [We'd love to hear your feedback.](mailto:support@taxjar.com)
 
+### August 2019
+
+#### 2019-08-22
+
+* <span class="badge badge--post">Feature</span> Order-level `exemption_type` param now accepts value `marketplace` to enable further support for marketplace exemptions.
+
 ### June 2019
 
 #### 2019-06-26

--- a/source/includes/endpoints/_taxes.md
+++ b/source/includes/endpoints/_taxes.md
@@ -4261,7 +4261,7 @@ to_street | string | optional | Street address where the order shipped to. <span
 amount | float | optional | Total amount of the order, **excluding shipping**. <span class="usage-note" data-tooltip="Either `amount` or `line_items` parameters are required to perform tax calculations." data-tooltip-position="top center">View Note</span>
 shipping | float | required | Total amount of shipping for the order.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
-exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, or `non_exempt`.  <span class="usage-note" data-tooltip="An `exemption_type` of `wholesale`, `government`, or `other` will result in an order being determined fully exempt. A value of `marketplace` or `non_exempt` will override a customer's `exemption_type` (based on their `customer_id`) and calculate tax." data-tooltip-position="top center">View Note</span>
 nexus_addresses[][id] | string | optional | Unique identifier of the given nexus address. <span class="usage-note" data-tooltip="Either an address on file, `nexus_addresses` parameter, or `from_` parameters are required to perform tax calculations." data-tooltip-position="top center">View Note</span>
 nexus_addresses[][country] | string | <span class="conditional" data-tooltip="If providing `nexus_addresses`, country is required." data-tooltip-position="top center">conditional</span> | Two-letter ISO country code for the nexus address.
 nexus_addresses[][zip] | string | optional | Postal code for the nexus address.
@@ -4300,7 +4300,7 @@ rate | float | Overall sales tax rate of the order (`amount_to_collect` &divide;
 has_nexus | bool | Whether or not you have [nexus](https://blog.taxjar.com/sales-tax-nexus-definition/) for the order based on an address on file, `nexus_addresses` parameter, or `from_` parameters.
 freight_taxable | bool | Freight taxability for the order.
 tax_source | string | [Origin-based or destination-based](https://blog.taxjar.com/charging-sales-tax-rates/) sales tax collection.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. If no `customer_id` or `exemption_type` is provided, no `exemption_type` is returned in the response.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, or `non_exempt`. If no `customer_id` or `exemption_type` is provided, no `exemption_type` is returned in the response.
 jurisdictions | object | Jurisdiction names for the order.
 breakdown | object | Breakdown of rates by jurisdiction for the order, shipping, and individual line items. If `has_nexus` is false or no line items are provided, no breakdown is returned in the response.
 

--- a/source/includes/endpoints/_transactions.md
+++ b/source/includes/endpoints/_transactions.md
@@ -391,7 +391,7 @@ transaction_id | string | Unique identifier of the given order transaction.
 user_id | integer | Unique identifier of the user who created the order transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, `non_exempt`, or `null`. <span class="usage-note" data-tooltip="A `null` value may be returned if the transaction does not have an exemption type or, if `marketplace` is passed to the `exemption_type` param, but the order's `to_state` does not have a marketplace facilitator law or the `transaction_date` is before the law took effect in that state." data-tooltip-position="top center">View Note</span>
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -787,7 +787,7 @@ amount | float | required | Total amount of the order with shipping, **excluding
 shipping | float | required | Total amount of shipping for the order in dollars.
 sales_tax | float | required | Total amount of sales tax collected for the order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
-exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, or `non_exempt`. <span class="usage-note" data-tooltip="If exemption_type is set to `wholesale`, `government`, or `other`, any order-level or line item `sales_tax` present in the order must be zero." data-tooltip-position="top center">View Note</span>
 line_items[][id] | string | optional | Unique identifier of the given line item.
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
@@ -817,7 +817,7 @@ transaction_id | string | Unique identifier of the given order transaction.
 user_id | integer | Unique identifier of the user who created the order transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, `non_exempt`, or `null`. <span class="usage-note" data-tooltip="A `null` value may be returned if the transaction does not have an exemption type or, if `marketplace` is passed to the `exemption_type` param, but the order's `to_state` does not have a marketplace facilitator law or the `transaction_date` is before the law took effect in that state." data-tooltip-position="top center">View Note</span>
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -1173,7 +1173,7 @@ amount | float | optional | Total amount of the order with shipping, **excluding
 shipping | float | optional | Total amount of shipping for the order in dollars.
 sales_tax | float | optional | Total amount of sales tax collected for the order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
-exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, or `non_exempt`. <span class="usage-note" data-tooltip="If exemption_type is set to `wholesale`, `government`, or `other`, any order-level or line item `sales_tax` present in the order must be zero." data-tooltip-position="top center">View Note</span>
 line_items[][id] | string | optional | Unique identifier of the given line item.
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
@@ -1201,7 +1201,7 @@ transaction_id | string | Unique identifier of the given order transaction.
 user_id | integer | Unique identifier of the user who created the order transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, `non_exempt`, or `null`. <span class="usage-note" data-tooltip="A `null` value may be returned if the transaction does not have an exemption type or, if `marketplace` is passed to the `exemption_type` param, but the order's `to_state` does not have a marketplace facilitator law or the `transaction_date` is before the law took effect in that state." data-tooltip-position="top center">View Note</span>
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -1814,7 +1814,7 @@ transaction_id | string | Unique identifier of the given refund transaction.
 user_id | integer | Unique identifier of the user who created the refund transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, `non_exempt`, or `null`. <span class="usage-note" data-tooltip="A `null` value may be returned if the transaction does not have an exemption type or, if `marketplace` is passed to the `exemption_type` param, but the order's `to_state` does not have a marketplace facilitator law or the `transaction_date` is before the law took effect in that state." data-tooltip-position="top center">View Note</span>
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -2224,7 +2224,7 @@ amount | float | required | Total amount of the refunded order with shipping, **
 shipping | float | required | Total amount of shipping for the refunded order in dollars.
 sales_tax | float | required | Total amount of sales tax collected for the refunded order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
-exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, or `non_exempt`. <span class="usage-note" data-tooltip="If exemption_type is set to `wholesale`, `government`, or `other`, any order-level or line item `sales_tax` present in the refund must be zero." data-tooltip-position="top center">View Note</span>
 line_items[][id] | string | optional | Unique identifier of the given line item.
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
@@ -2254,7 +2254,7 @@ transaction_id | string | Unique identifier of the given refund transaction.
 user_id | integer | Unique identifier of the user who created the refund transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, `non_exempt`, or `null`. <span class="usage-note" data-tooltip="A `null` value may be returned if the transaction does not have an exemption type or, if `marketplace` is passed to the `exemption_type` param, but the order's `to_state` does not have a marketplace facilitator law or the `transaction_date` is before the law took effect in that state." data-tooltip-position="top center">View Note</span>
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.
@@ -2611,7 +2611,7 @@ amount | float | optional | Total amount of the refunded order with shipping, **
 shipping | float | optional | Total amount of shipping for the refunded order in dollars.
 sales_tax | float | optional | Total amount of sales tax collected for the refunded order in dollars.
 customer_id | string | optional | Unique identifier of the given customer for exemptions.
-exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`.
+exemption_type | string | optional | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, or `non_exempt`. <span class="usage-note" data-tooltip="If exemption_type is set to `wholesale`, `government`, or `other`, any order-level or line item `sales_tax` present in the refund must be zero." data-tooltip-position="top center">View Note</span>
 line_items[][id] | string | optional | Unique identifier of the given line item.
 line_items[][quantity] | integer | optional | Quantity for the item.
 line_items[][product_identifier] | string | optional | Product identifier for the item.
@@ -2639,7 +2639,7 @@ transaction_id | string | Unique identifier of the given refund transaction.
 user_id | integer | Unique identifier of the user who created the refund transaction.
 transaction_date | datetime | The date/time the transaction was originally recorded.
 provider | string | Source of where the transaction was originally recorded.
-exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `other`, or `non_exempt`. A `null` value may be returned if the transaction does not have an exemption type.
+exemption_type | string | Type of exemption for the order: `wholesale`, `government`, `marketplace`, `other`, `non_exempt`, or `null`. <span class="usage-note" data-tooltip="A `null` value may be returned if the transaction does not have an exemption type or, if `marketplace` is passed to the `exemption_type` param, but the order's `to_state` does not have a marketplace facilitator law or the `transaction_date` is before the law took effect in that state." data-tooltip-position="top center">View Note</span>
 from_country | string | Two-letter ISO country code of the country where the order shipped from.
 from_zip | string | Postal code where the order shipped from (5-Digit ZIP or ZIP+4).
 from_state | string | Two-letter ISO state code where the order shipped from.


### PR DESCRIPTION
We've added `marketplace` as an acceptable value passed to the `exemption_type` param, which now accepts `wholesale`, `government`, `marketplace`, `other`, or `non_exempt`.

For transactions, an `exemption_type` of `marketplace` will be returned from the API if passed in the request **_and_** the order's `to_state` has a marketplace facilitator law _**and**_ `transaction_date` occurs after the law took effect in the state.