### PR TITLE
Scroll to top of categories list when navigating pages

### DIFF
--- a/source/javascripts/app/datatable.js
+++ b/source/javascripts/app/datatable.js
@@ -1,7 +1,7 @@
 (function (global) {
   'use strict';
 
-  $('.datatable').next('table').DataTable({
+  var table = $('.datatable').next('table').DataTable({
     autoWidth: false,
     info: false,
     paging: true,
@@ -19,6 +19,13 @@
       searchPlaceholder: 'Search categories...',
       zeroRecords: 'No matching categories found'
     }
+  });
+
+  table.on('page.dt', function() {
+    $([document.documentElement, document.body]).animate({
+      // Note: '#get-list-tax-categories' scrolls too far up on mobile so using '#request'
+      scrollTop: $('#request').offset().top
+    }, 'slow');
   });
 
 })(window);


### PR DESCRIPTION
This PR improves UX when perusing tax codes in the categories list. We'll now scroll up to the top of the categories list when a user navigates between pages. The easiest way to show this is through GIFs:

**Before**
![Before](https://user-images.githubusercontent.com/26824724/70870605-265ea800-1f4a-11ea-86f3-2cc6aa328d1b.gif)

**After**
![After](https://user-images.githubusercontent.com/26824724/70870609-3aa2a500-1f4a-11ea-809f-67ae6eedd7f5.gif)
