### PR TITLE
Fix .tocify-wrapper overflow issue

### DIFF
--- a/source/javascripts/app/docsearch.js
+++ b/source/javascripts/app/docsearch.js
@@ -5,14 +5,14 @@
   // when docsearch dropdown is shown, overflow should be visible
   // when docsearch dropdown is hidden, overflow should be auto/hidden
 
-  function resetOverflow () {
+  function resetOverflow() {
     $('.tocify-wrapper').css({
       'overflow-y': 'auto',
       'overflow-x': 'hidden'
     });
   }
 
-  function createSearchInputs (/* ...selectors */) {
+  function createSearchInputs(/* ...selectors */) {
     $.each(arguments, function(_, selector) {
       docsearch({
         appId: '7ZBSP80X0K',
@@ -20,7 +20,7 @@
         indexName: 'developers.taxjar.com',
         inputSelector: selector
       })
-        .autocomplete.on('autocomplete:shown', function () {
+        .autocomplete.on('autocomplete:shown', function() {
           $('.tocify-wrapper').css({
             'overflow-y': 'visible',
             'overflow-x': 'visible'
@@ -28,7 +28,7 @@
         })
         .on('autocomplete:closed', resetOverflow);
 
-      $(selector).on('keyup', function (e) {
+      $(selector).on('keyup', function(e) {
         if (e.keyCode === 27 || $(this).val() === '') {
           resetOverflow();
         }

--- a/source/javascripts/app/docsearch.js
+++ b/source/javascripts/app/docsearch.js
@@ -1,0 +1,40 @@
+(function() {
+'use strict';
+
+  // handle .tocify-wrapper overflow issue:
+  // when docsearch dropdown is shown, overflow should be visible
+  // when docsearch dropdown is hidden, overflow should be auto/hidden
+
+  function resetOverflow () {
+    $('.tocify-wrapper').css({
+      'overflow-y': 'auto',
+      'overflow-x': 'hidden'
+    });
+  }
+
+  function createSearchInputs (/* ...selectors */) {
+    $.each(arguments, function(_, selector) {
+      docsearch({
+        appId: '7ZBSP80X0K',
+        apiKey: '2a9d77b7d7b611725a62fd9ffb522880',
+        indexName: 'developers.taxjar.com',
+        inputSelector: selector
+      })
+        .autocomplete.on('autocomplete:shown', function () {
+          $('.tocify-wrapper').css({
+            'overflow-y': 'visible',
+            'overflow-x': 'visible'
+          });
+        })
+        .on('autocomplete:closed', resetOverflow);
+
+      $(selector).on('keyup', function (e) {
+        if (e.keyCode === 27 || $(this).val() === '') {
+          resetOverflow();
+        }
+      });
+    });
+  }
+
+  createSearchInputs('#docsearch', '#docsearch-mobile');
+})();

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -137,6 +137,7 @@ under the License.
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 
     <% if current_page.data.search %>
       <%= javascript_include_tag  "all" %>
@@ -163,22 +164,6 @@ under the License.
 
       ga('create', 'UA-32676850-1', 'auto');
       ga('send', 'pageview');
-    </script>
-
-    <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
-    <script>
-      docsearch({
-        appId: '7ZBSP80X0K',
-        apiKey: '2a9d77b7d7b611725a62fd9ffb522880',
-        indexName: 'developers.taxjar.com',
-        inputSelector: '#docsearch'
-      });
-      docsearch({
-        appId: '7ZBSP80X0K',
-        apiKey: '2a9d77b7d7b611725a62fd9ffb522880',
-        indexName: 'developers.taxjar.com',
-        inputSelector: '#docsearch-mobile'
-      });
     </script>
   </body>
 </html>

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -253,6 +253,8 @@ summary {
 
 .tocify-wrapper {
   @include transition(left ease-in-out 0.3s);
+  overflow-y: auto;
+  overflow-x: hidden;
   position: fixed;
   z-index: 30;
   top: 69px;


### PR DESCRIPTION
While adding [docsearch](https://community.algolia.com/docsearch/) to the developer site in [#56](https://github.com/taxjar/taxjar-api-docs/pull/56/files#diff-a3e5e73c50070e39b8c37ddf7773d6e5L251), we hid the overflow from `.tocify-wrapper` so that the docsearch dropdown was entirely visible. On smaller screens, however, this disallows scrolling to view items at the bottom of the sidebar.

This PR adds logic to the styling as follows:

- When docsearch dropdown is shown, overflow is visible.
- When docsearch dropdown is hidden, overflow is auto/hidden.

Before (no scrolling):

![before (no scrolling)](https://user-images.githubusercontent.com/26824724/73286155-f42ca100-41ab-11ea-9155-5ef939bc5934.gif)

After (scrolling):

![after (scrolling)](https://user-images.githubusercontent.com/26824724/73286196-04dd1700-41ac-11ea-8fdc-c6e8db76ad32.gif)