### PR TITLE
Fix `update_customer` and `update_refund` examples

### DIFF
--- a/source/includes/endpoints/_customers.md
+++ b/source/includes/endpoints/_customers.md
@@ -909,8 +909,7 @@ customer = client.update_customer({
 import taxjar
 client = taxjar.Client(api_key='9e0cd62a22f451701f29c3bde214')
 
-customer = client.update_customer({
-  'customer_id': '123',
+customer = client.update_customer('123', {
   'exemption_type': 'wholesale',
   'name': 'Sterling Cooper',
   'exempt_regions': [

--- a/source/includes/endpoints/_transactions.md
+++ b/source/includes/endpoints/_transactions.md
@@ -2822,7 +2822,7 @@ PUT https://api.taxjar.com/v2/transactions/refunds/:transaction_id
 require "taxjar"
 client = Taxjar::Client.new(api_key: "9e0cd62a22f451701f29c3bde214")
 
-order = client.update_refund({
+refund = client.update_refund({
   :transaction_id => '321',
   :amount => -17,
   :shipping => -2,
@@ -2844,7 +2844,6 @@ import taxjar
 client = taxjar.Client(api_key='9e0cd62a22f451701f29c3bde214')
 
 refund = client.update_refund('321', {
-  'transaction_id': '321',
   'amount': -17,
   'shipping': -2,
   'sales_tax': -0.95,


### PR DESCRIPTION
Both the Python client's `update_customer` and `update_refund` methods require two arguments—an ID and the details to update.

This PR updates examples to show the correct usage. See [#21 in taxjar-python for more](https://github.com/taxjar/taxjar-python/pull/21).