### PR TITLE
INT-594 Digital Tax Codes as of March 9, 2020

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,6 +2,17 @@
 
 Stay on top of new developer-facing features, accuracy improvements, and bug fixes for our sales tax API. Have a request? Encounter an issue? [We'd love to hear your feedback.](mailto:support@taxjar.com)
 
+### March 2020
+
+#### 2020-03-09
+
+* <span class="badge badge--get">Accuracy</span> 2 more tax categories for digital goods and software now available.
+<table>
+  <th>Code</th><th>Category</th>
+  <tr><td>55111500A9210</td><td>Electronic content bundle - Delivered electronically with permanent rights of usage and streamed</td></tr>
+  <tr><td>55111500A9220</td><td>Electronic content bundle - Delivered electronically with less than permanent rights of usage and streamed</td></tr>
+</table>
+
 ### January 2020
 
 #### 2020-01-23

--- a/source/includes/endpoints/_categories.md
+++ b/source/includes/endpoints/_categories.md
@@ -665,7 +665,8 @@ Returns a `categories` JSON object with an array of product categories and corre
 | Clothing - Synthetic Fur Hat | 53102504A0002 | <span class="flag-icon flag-icon-us" data-tooltip="United States" data-tooltip-position="top center"></span> | \*(PLUS ONLY)\* Clothing - Synthetic Fur Hat |
 | Clothing - Synthetic Fur Vest | 53103100A0002 | <span class="flag-icon flag-icon-us" data-tooltip="United States" data-tooltip-position="top center"></span> | \*(PLUS ONLY)\* Clothing - Synthetic Fur Vest |
 | Clothing - Synthetic Fur Poncho or Cape | 53101806A0002 | <span class="flag-icon flag-icon-us" data-tooltip="United States" data-tooltip-position="top center"></span> | \*(PLUS ONLY)\* Clothing - Synthetic Fur Poncho or Cape |
-
+| Electronic content bundle - Delivered electronically with permanent rights of usage and streamed | 55111500A9210 | <span class="flag-icon flag-icon-us" data-tooltip="United States" data-tooltip-position="top center"></span> | \*(PLUS ONLY)\* Electronic content bundle - Delivered electronically with permanent rights of usage and streamed |
+| Electronic content bundle - Delivered electronically with less than permanent rights of usage and streamed | 55111500A9220 | <span class="flag-icon flag-icon-us" data-tooltip="United States" data-tooltip-position="top center"></span> | \*(PLUS ONLY)\* Electronic content bundle - Delivered electronically with less than permanent rights of usage and streamed |
 
 #### Attributes
 


### PR DESCRIPTION
This PR documents two new product tax codes for digital goods and software.

| Code | Name |
| ------- | --------- |
| 55111500A9210 | Electronic content bundle - Delivered electronically with permanent rights of usage and streamed |
| 55111500A9220 | Electronic content bundle - Delivered electronically with less than permanent rights of usage and streamed |