### PR TITLE
INT-773 & INT-785 Remove references to SmartCalcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TaxJar API Docs
 
-SmartCalcs API documentation for TaxJar, powered by [Middleman](https://github.com/middleman/middleman).
+TaxJar API documentation, powered by [Middleman](https://github.com/middleman/middleman).
 
 ## Getting Started
 

--- a/source/guides.md
+++ b/source/guides.md
@@ -1,6 +1,6 @@
 ---
 title: Sales Tax API Guides
-description: "Tips and tricks on how to use SmartCalcs, TaxJar's sales tax API."
+description: "Tips and tricks on how to use TaxJar's sales tax API."
 preferred_url: https://developers.taxjar.com/api/guides/
 toc_header: "API Guides"
 
@@ -155,7 +155,7 @@ $ curl https://api.taxjar.com/v2/taxes \
 }
 ```
 
-In many states (and countries) certain products are either exempted from sales tax, taxed at a lower rate, or even exempted below certain prices and within only certain jurisdictions. To help you make an accurate determination about how an individual item should be taxed, [SmartCalcs](https://www.taxjar.com/api/) allows you to submit a `product_tax_code` parameter with each `line_item` in an order.
+In many states (and countries) certain products are either exempted from sales tax, taxed at a lower rate, or even exempted below certain prices and within only certain jurisdictions. To help you make an accurate determination about how an individual item should be taxed, [the TaxJar API](https://www.taxjar.com/api/) allows you to submit a `product_tax_code` parameter with each `line_item` in an order.
 
 Let’s take one of the most commonly cited examples: clothing items sold in the state of New York that fall below the threshold of $110. Interestingly, these types of items are exempt from the state tax rate, but are only exempt from county taxes in certain jurisdictions. Fortunately, you need not worry about those rules. Simply pass in a value of **20010** in the `product_tax_code` parameter of a `line_item`, and we’ll do the work for you.
 
@@ -163,23 +163,23 @@ Let’s take one of the most commonly cited examples: clothing items sold in the
 
 Here’s an example of an order in NY that contains a mixed order of exempt and non-exempt clothing items. Interestingly, we’ve chosen a destination address in a county where the clothing exemption does not apply (it only applies at the state level).
 
-As you can see in the response, SmartCalcs figures out the taxability by item, by jurisdiction. All you need to do is tell us an item is “Clothing” using `product_tax_code` **20010**.
+As you can see in the response, the TaxJar API figures out the taxability by item, by jurisdiction. All you need to do is tell us an item is “Clothing” using `product_tax_code` **20010**.
 
 To obtain the current list of supported product_tax_codes, they are always available via our [Categories endpoint](https://developers.taxjar.com/api/#categories).
 
 #### Additional Reminder
 
-If no `product_tax_code` is submitted with a `line_item`, then that item is deemed to be fully taxable. You do not need to send any information to tell SmartCalcs that something is taxable. It assumes that, unless told otherwise through the existence of a `product_tax_code`.
+If no `product_tax_code` is submitted with a `line_item`, then that item is deemed to be fully taxable. You do not need to send any information to tell TaxJar that something is taxable. It assumes that, unless told otherwise through the existence of a `product_tax_code`.
 
 # Handling Nexus
 
 The very first bit of logic used when calculating sales tax is the notion of [nexus](https://blog.taxjar.com/sales-tax-nexus-definition/). In short, whether or not your business has sufficient presence within a taxing jurisdiction to require you to remit sales tax.
 
-Using TaxJar's [SmartCalcs API](https://www.taxjar.com/api/), there are two ways for you let us know if you have nexus for a given order:
+Using the [TaxJar API](https://www.taxjar.com/api/), there are two ways for you let us know if you have nexus for a given order:
 
-1. If you are calculating tax just for your own business, you can store all of your nexus information within your [TaxJar account](https://app.taxjar.com/api_sign_up/). Just use the [State Settings page](https://app.taxjar.com/account#states) to enter all of your business locations. When you make a call to SmartCalcs with your API token, we will look at your nexus information on file and calculate sales tax when appropriate. Of course, our ability to calculate properly will depend on your maintaining an accurate list of nexus locations. To add states and nexus locations, just go to the [State Settings page](https://app.taxjar.com/account#states) and click the **Add State with Nexus** button.
+1. If you are calculating tax just for your own business, you can store all of your nexus information within your [TaxJar account](https://app.taxjar.com/api_sign_up/). Just use the [State Settings page](https://app.taxjar.com/account#states) to enter all of your business locations. When you make a call to the TaxJar API with your API token, we will look at your nexus information on file and calculate sales tax when appropriate. Of course, our ability to calculate properly will depend on your maintaining an accurate list of nexus locations. To add states and nexus locations, just go to the [State Settings page](https://app.taxjar.com/account#states) and click the **Add State with Nexus** button.
 
-2. If you would rather not load your locations into your TaxJar account or if you are trying to perform calculations for other merchants, you may pass in nexus information with each call to SmartCalcs. At minimum, if you pass in valid values for nexus_country and nexus_state, we can make a proper nexus determination.
+2. If you would rather not load your locations into your TaxJar account or if you are trying to perform calculations for other merchants, you may pass in nexus information with each call to the TaxJar API. At minimum, if you pass in valid values for nexus_country and nexus_state, we can make a proper nexus determination.
 
 > No Nexus, Non-Taxable Sale
 
@@ -243,7 +243,7 @@ You have set up your TaxJar account and have an API token, but have no nexus add
 
 You should see a response similar to the one on the right.
 
-TaxJar has no knowledge of your nexus, and because no nexus information was passed into SmartCalcs, we interpret it as a non-taxable sale.
+TaxJar has no knowledge of your nexus, and because no nexus information was passed into the TaxJar API, we interpret it as a non-taxable sale.
 
 Now, send the same order in, but with the optional `nexus_addresses[]` parameters filled in.
 
@@ -259,17 +259,17 @@ In general, we recommend always passing in the address information from which an
 
 If you are building or operating a [marketplace platform](https://www.taxjar.com/marketplaces/), allowing multiple sellers to list and sell their items through you, there are a few different options.
 
-First, if you are the merchant of record, then you are responsible for collecting and remitting sales tax for all of those sales. In such a case, you would use TaxJar's [SmartCalcs API](https://www.taxjar.com/api/) to calculate the proper amount of tax to collect, then, if you wish to use TaxJar for reporting and filing, send completed orders to TaxJar using the same API token that is tied to your account.
+First, if you are the merchant of record, then you are responsible for collecting and remitting sales tax for all of those sales. In such a case, you would use the [TaxJar API](https://www.taxjar.com/api/) to calculate the proper amount of tax to collect, then, if you wish to use TaxJar for reporting and filing, send completed orders to TaxJar using the same API token that is tied to your account.
 
-In most cases that we’ve seen, marketplaces are not acting as the seller of record, so the sales tax responsibilities and liabilities fall to the merchant. However, most marketplaces, as a courtesy, like to provide sales tax calculation services at the point of checkout. If you are building/operating such a marketplace, then you would use your TaxJar account and its API token to make calls to our SmartCalcs service, sending in order information and receiving the corresponding sales tax to collect.
+In most cases that we’ve seen, marketplaces are not acting as the seller of record, so the sales tax responsibilities and liabilities fall to the merchant. However, most marketplaces, as a courtesy, like to provide sales tax calculation services at the point of checkout. If you are building/operating such a marketplace, then you would use your TaxJar account and its API token to make calls to our API, sending in order information and receiving the corresponding sales tax to collect.
 
-Because we won’t know anything about a given merchant when you call SmartCalcs with their order information, you will need to submit additional parameters to get an accurate sales tax rate. For example, we need to know in what jurisdictions the merchant has nexus in order to determine whether an order is even subject to sales tax. For this purpose, we have the `nexus_address` parameters. Simply pass in a list of addresses with each order to get proper nexus determination. Of course, in order to provide this to SmartCalcs, you will need to have this information stored for each merchant. As such, we recommend storing all merchant business location addresses in your system, so that it is easy to pass in when calculating sales tax.
+Because we won’t know anything about a given merchant when you call the TaxJar API with their order information, you will need to submit additional parameters to get an accurate sales tax rate. For example, we need to know in what jurisdictions the merchant has nexus in order to determine whether an order is even subject to sales tax. For this purpose, we have the `nexus_address` parameters. Simply pass in a list of addresses with each order to get proper nexus determination. Of course, in order to provide this to the TaxJar API, you will need to have this information stored for each merchant. As such, we recommend storing all merchant business location addresses in your system, so that it is easy to pass in when calculating sales tax.
 
 #### In Summary
 
-- If you're building or operating a marketplace, TaxJar's [SmartCalcs API](https://www.taxjar.com/api/) can help you calculate sales tax.
+- If you're building or operating a marketplace, the [TaxJar API](https://www.taxjar.com/api/) can help you calculate sales tax.
 
-- For most marketplaces where each merchant acts as the seller of record, you will need to submit `nexus_address` parameters for the merchant in every SmartCalcs API call.
+- For most marketplaces where each merchant acts as the seller of record, you will need to submit `nexus_address` parameters for the merchant in every TaxJar API call.
 
 - We recommend storing all merchant business location addresses in your system to pass in when calculating sales tax.
 
@@ -279,7 +279,7 @@ We also offer an affiliate program, which provides a revenue sharing opportunity
 
 # Custom Apps & Carts
 
-While SmartCalcs was originally created as a way for eCommerce marketplaces to provide compliance help for merchants, our [transaction endpoints](https://developers.taxjar.com/api/#transactions) also make it possible to build an integration from any shopping cart, invoicing tool or accounting platform to TaxJar.
+While the TaxJar API was originally created as a way for eCommerce marketplaces to provide compliance help for merchants, our [transaction endpoints](https://developers.taxjar.com/api/#transactions) also make it possible to build an integration from any shopping cart, invoicing tool or accounting platform to TaxJar.
 
 You only need two things to make this possible:
 
@@ -297,9 +297,9 @@ How and when to send these transactions to TaxJar is entirely up to you. Some po
 
 ### Avoiding Unnecessary API Calls
 
-Want a simple way to reduce the number of SmartCalcs calls you need to make? Compare the delivery address of an order or invoice to the list of `nexus_addresses` for your business or merchant. **If the delivery address falls in a different state than those in which your business (or merchant of sale) has nexus, no sales tax need be collected.** *Note, this only works for US-based sales. Overseas sales, especially in the European Union, have different rules.*
+Want a simple way to reduce the number of TaxJar API calls you need to make? Compare the delivery address of an order or invoice to the list of `nexus_addresses` for your business or merchant. **If the delivery address falls in a different state than those in which your business (or merchant of sale) has nexus, no sales tax need be collected.** *Note, this only works for US-based sales. Overseas sales, especially in the European Union, have different rules.*
 
-Furthermore, many carts estimate taxes in the cart or preview pages prior to checkout. You could consider eliminating this estimate or at least delaying it until the shopper is closer to completing the purchase. During checkout make sure you wait to call SmartCalcs tax calculations until the shipping address is complete. Many customers use an [address validation service](https://developers.taxjar.com/blog/address-validation-apis-and-plugins/) to ensure a valid shipping address prior to calling SmartCalcs with the final order totals and shipping `from` and `to` addresses.
+Furthermore, many carts estimate taxes in the cart or preview pages prior to checkout. You could consider eliminating this estimate or at least delaying it until the shopper is closer to completing the purchase. During checkout make sure you wait to make a request to calculate tax until the shipping address is complete. Many customers use an [address validation service](https://developers.taxjar.com/blog/address-validation-apis-and-plugins/) to ensure a valid shipping address prior to calling the TaxJar API with the final order totals and shipping `from` and `to` addresses.
 
 # API Integrations
 
@@ -314,7 +314,7 @@ We currently provide official integrations for the following platforms:
 
 ## Magento
 
-Our Magento sales tax extensions currently support Magento 1.7.x - 1.9.x and Magento 2.0+. SmartCalcs is fully integrated for checkout calculations and zip-based rate imports as a fallback.
+Our Magento sales tax extensions currently support Magento 1.7.x - 1.9.x and Magento 2.0+. The TaxJar API is fully integrated for checkout calculations and zip-based rate imports as a fallback.
 
 - Install our [Magento 2](https://marketplace.magento.com/taxjar-module-taxjar.html) or [Magento 1](https://marketplace.magento.com/taxjar-taxjar-salestaxautomation.html) extension from Magento Marketplace
 - Get started and learn how it works with our [Extension Guide](https://www.taxjar.com/guides/integrations/magento/)

--- a/source/guides/csharp.md
+++ b/source/guides/csharp.md
@@ -1,6 +1,6 @@
 ---
 title: Sales Tax API Guide for C# / .NET
-description: "How to use SmartCalcs with our official C# / .NET client."
+description: "How to use the TaxJar API with our official C# / .NET client."
 preferred_url: https://developers.taxjar.com/api/guides/csharp/
 ---
 
@@ -35,7 +35,7 @@ var client = new TaxjarApi();
 var client = new TaxjarApi("[Your TaxJar API Key]");
 ```
 
-In order to make requests to our [sales tax API](https://www.taxjar.com/smartcalcs/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
+In order to make requests to our [sales tax API](https://www.taxjar.com/api/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
 
 We recommend placing the TaxJar API token inside your project's Web.config or App.config file to keep sensitive credentials outside of your code.
 
@@ -225,6 +225,6 @@ Error Code | Meaning
 If you have any questions about using our sales tax API for C# / .NET, please [contact us](https://www.taxjar.com/contact/) or tweet [@TaxJarDev](https://twitter.com/TaxJarDev). We'll help you out as soon as we can!
 
 - [C# / .NET Sales Tax API Reference](/api/reference/?csharp)
-- [General SmartCalcs FAQs](https://support.taxjar.com/knowledge_base/categories/smartcalcs)
+- [General TaxJar API FAQs](https://support.taxjar.com/category/233-taxjar-api)
 - [taxjar.net on GitHub](https://github.com/taxjar/taxjar.net)
 - [taxjar.net on NuGet](https://www.nuget.org/packages/TaxJar/)

--- a/source/guides/go.md
+++ b/source/guides/go.md
@@ -1,6 +1,6 @@
 ---
 title: Sales Tax API Guide for Go
-description: "How to use SmartCalcs with our official Go client."
+description: "How to use the TaxJar API with our official Go client."
 preferred_url: https://developers.taxjar.com/api/guides/go/
 ---
 
@@ -37,7 +37,7 @@ func main() {
 }
 ```
 
-In order to make requests to our [sales tax API](https://www.taxjar.com/smartcalcs/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
+In order to make requests to our [sales tax API](https://www.taxjar.com/api/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
 
 We recommend using an environment variable such as `TAXJAR_API_KEY` to keep sensitive credentials like API tokens outside of your code.
 
@@ -284,6 +284,6 @@ When invalid data is sent to TaxJar or we encounter an error, we'll return a [`T
 If you have any questions about using our sales tax API for Go, please [contact us](https://www.taxjar.com/contact/) or tweet [@TaxJarDev](https://twitter.com/TaxJarDev). We'll help you out as soon as we can!
 
 - [Go Sales Tax API Reference](/api/reference/?go)
-- [General SmartCalcs FAQs](https://support.taxjar.com/knowledge_base/categories/smartcalcs)
+- [General TaxJar API FAQs](https://support.taxjar.com/category/233-taxjar-api)
 - [taxjar-go on GitHub](https://github.com/taxjar/taxjar-go)
 - [taxjar-go on GoDoc](https://godoc.org/github.com/taxjar/taxjar-go)

--- a/source/guides/java.md
+++ b/source/guides/java.md
@@ -1,6 +1,6 @@
 ---
 title: Sales Tax API Guide for Java
-description: "How to use SmartCalcs with our official Java client."
+description: "How to use the TaxJar API with our official Java client."
 preferred_url: https://developers.taxjar.com/api/guides/java/
 ---
 
@@ -45,7 +45,7 @@ public class AuthenticationExample {
 }
 ```
 
-In order to make requests to our [sales tax API](https://www.taxjar.com/smartcalcs/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
+In order to make requests to our [sales tax API](https://www.taxjar.com/api/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
 
 We recommend using an environment variable for the TaxJar API token to keep sensitive credentials outside of your code.
 
@@ -283,6 +283,6 @@ Error Code | Meaning
 If you have any questions about using our sales tax API for Java, please [contact us](https://www.taxjar.com/contact/) or tweet [@TaxJarDev](https://twitter.com/TaxJarDev). We'll help you out as soon as we can!
 
 - [Java Sales Tax API Reference](/api/reference/?java)
-- [General SmartCalcs FAQs](https://support.taxjar.com/knowledge_base/categories/smartcalcs)
+- [General TaxJar API FAQs](https://support.taxjar.com/category/233-taxjar-api)
 - [taxjar-java on GitHub](https://github.com/taxjar/taxjar-java)
 - [taxjar-java on The Central Repository](https://search.maven.org/#artifactdetails%7Ccom.taxjar%7Ctaxjar-java%7C1.0.0%7Cjar)

--- a/source/guides/node.md
+++ b/source/guides/node.md
@@ -1,6 +1,6 @@
 ---
 title: Sales Tax API Guide for Node
-description: "How to use SmartCalcs with our official Node client."
+description: "How to use the TaxJar API with our official Node client."
 preferred_url: https://developers.taxjar.com/api/guides/node/
 ---
 
@@ -46,7 +46,7 @@ const client = new Taxjar({
 });
 ```
 
-In order to make requests to our [sales tax API](https://www.taxjar.com/smartcalcs/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
+In order to make requests to our [sales tax API](https://www.taxjar.com/api/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
 
 We recommend using a `.env` file with a package such as [dotenv](https://github.com/motdotla/dotenv) to keep sensitive credentials like API tokens outside of your code.
 
@@ -236,6 +236,6 @@ Error Code | Meaning
 If you have any questions about using our sales tax API for Node, please [contact us](https://www.taxjar.com/contact/) or tweet [@TaxJarDev](https://twitter.com/TaxJarDev). We'll help you out as soon as we can!
 
 - [Node Sales Tax API Reference](/api/reference/?node)
-- [General SmartCalcs FAQs](https://support.taxjar.com/knowledge_base/categories/smartcalcs)
+- [General TaxJar API FAQs](https://support.taxjar.com/category/233-taxjar-api)
 - [taxjar-node on GitHub](https://github.com/taxjar/taxjar-node)
 - [taxjar-node on NPM](https://npmjs.org/package/taxjar)

--- a/source/guides/php.md
+++ b/source/guides/php.md
@@ -1,6 +1,6 @@
 ---
 title: Sales Tax API Guide for PHP
-description: "How to use SmartCalcs with our official PHP client."
+description: "How to use the TaxJar API with our official PHP client."
 preferred_url: https://developers.taxjar.com/api/guides/php/
 ---
 
@@ -42,7 +42,7 @@ Using Composer's [autoloading](https://getcomposer.org/doc/01-basic-usage.md#aut
 
 ### Passing Your API Token
 
-In order to make requests to our [sales tax API](https://www.taxjar.com/smartcalcs/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
+In order to make requests to our [sales tax API](https://www.taxjar.com/api/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
 
 We recommend using a `.env` file with a library such as [PHP dotenv](https://github.com/vlucas/phpdotenv) to keep sensitive credentials like API tokens outside of your code.
 
@@ -227,6 +227,6 @@ Error Code | Meaning
 If you have any questions about using our sales tax API for PHP, please [contact us](https://www.taxjar.com/contact/) or tweet [@TaxJarDev](https://twitter.com/TaxJarDev). We'll help you out as soon as we can!
 
 - [PHP Sales Tax API Reference](/api/reference/?php)
-- [General SmartCalcs FAQs](https://support.taxjar.com/knowledge_base/categories/smartcalcs)
+- [General TaxJar API FAQs](https://support.taxjar.com/category/233-taxjar-api)
 - [taxjar/taxjar-php on GitHub](https://github.com/taxjar/taxjar-php)
 - [taxjar/taxjar-php on Packagist](https://packagist.org/packages/taxjar/taxjar-php)

--- a/source/guides/python.md
+++ b/source/guides/python.md
@@ -1,6 +1,6 @@
 ---
 title: Sales Tax API Guide for Python
-description: "How to use SmartCalcs with our official Python client."
+description: "How to use the TaxJar API with our official Python client."
 preferred_url: https://developers.taxjar.com/api/guides/python/
 ---
 
@@ -24,7 +24,7 @@ client = taxjar.Client(api_key='9e0cd62a22f451701f29c3bde214') # Useful for quic
 client = taxjar.Client(api_key=os.environ.get('TAXJAR_API_KEY')) # Recommended
 ```
 
-In order to make requests to our [sales tax API](https://www.taxjar.com/smartcalcs/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
+In order to make requests to our [sales tax API](https://www.taxjar.com/api/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
 
 We recommend using a `.env` file with a package such as [python-dotenv](https://github.com/theskumar/python-dotenv) to keep sensitive credentials like API tokens outside of your code.
 
@@ -191,6 +191,6 @@ Error Code | Meaning
 If you have any questions about using our sales tax API for Python, please [contact us](https://www.taxjar.com/contact/) or tweet [@TaxJarDev](https://twitter.com/TaxJarDev). We'll help you out as soon as we can!
 
 - [Python Sales Tax API Reference](/api/reference/?python)
-- [General SmartCalcs FAQs](https://support.taxjar.com/knowledge_base/categories/smartcalcs)
+- [General TaxJar API FAQs](https://support.taxjar.com/category/233-taxjar-api)
 - [taxjar-python on GitHub](https://github.com/taxjar/taxjar-python)
 - [taxjar-python on PyPI](https://pypi.python.org/pypi/taxjar)

--- a/source/guides/ruby.md
+++ b/source/guides/ruby.md
@@ -1,6 +1,6 @@
 ---
 title: Sales Tax API Guide for Ruby
-description: "How to use SmartCalcs with our official Ruby client."
+description: "How to use the TaxJar API with our official Ruby client."
 preferred_url: https://developers.taxjar.com/api/guides/ruby/
 ---
 
@@ -30,7 +30,7 @@ client = Taxjar::Client.new(api_key: '48ceecccc8af930bd02597aec0f84a78') # Usefu
 client = Taxjar::Client.new(api_key: ENV['TAXJAR_API_KEY']) # Recommended
 ```
 
-In order to make requests to our [sales tax API](https://www.taxjar.com/smartcalcs/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
+In order to make requests to our [sales tax API](https://www.taxjar.com/api/) and get data back, you'll need to pass your TaxJar API token. If you don't already have a TaxJar account, [sign up to get your token](https://app.taxjar.com/api_sign_up/).
 
 We recommend using a `.env` file with a gem such as [dotenv](https://github.com/bkeepers/dotenv) to keep sensitive credentials like API tokens outside of your code.
 
@@ -198,6 +198,6 @@ Taxjar::Error::ServiceUnavailable | Service Unavailable -- We're temporarily off
 If you have any questions about using our sales tax API for Ruby, please [contact us](https://www.taxjar.com/contact/) or tweet [@TaxJarDev](https://twitter.com/TaxJarDev). We'll help you out as soon as we can!
 
 - [Ruby Sales Tax API Reference](/api/reference/?ruby)
-- [General SmartCalcs FAQs](https://support.taxjar.com/knowledge_base/categories/smartcalcs)
+- [General TaxJar API FAQs](https://support.taxjar.com/category/233-taxjar-api)
 - [taxjar-ruby on GitHub](https://github.com/taxjar/taxjar-ruby)
 - [taxjar-ruby on RubyGems](https://rubygems.org/gems/taxjar-ruby)

--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -508,7 +508,7 @@ Stay on top of new developer-facing features, accuracy improvements, and bug fix
 
 #### 2018-08-05
 
-* <span class="badge badge--put">Platform</span> Updated DNS records. SmartCalcs will now redirect traffic from HTTP to HTTPS via 301 redirect. Double slashes in URLs are no longer supported (e.g. "//v2/taxes").
+* <span class="badge badge--put">Platform</span> Updated DNS records. The TaxJar API will now redirect traffic from HTTP to HTTPS via 301 redirect. Double slashes in URLs are no longer supported (e.g. "//v2/taxes").
 
 #### 2018-08-02
 

--- a/source/javascripts/app/popover.js
+++ b/source/javascripts/app/popover.js
@@ -19,7 +19,7 @@
           target: $(this).find('> span').get(0),
           classes: 'drop-theme-taxjar-popovers',
           content: 'When passing monetary values to our API, we will convert them to high-precision decimals. ' +
-                   'SmartCalcs performs arbitrary-precision decimal arithmetic for accurately calculating sales tax.',
+                   'The TaxJar API performs arbitrary-precision decimal arithmetic for accurately calculating sales tax.',
           position: 'top center',
           openOn: 'hover'
         });

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -55,7 +55,7 @@ under the License.
                 <li><a href="/integrations/">Integrations</a></li>
                 <li><a href="https://status.taxjar.com"><span>API</span> Status</a></li>
                 <li><a href="/blog/">Dev Blog</a></li>
-                <li><a href="https://support.taxjar.com/knowledge_base/categories/smartcalcs" target="_blank">Support</a></li>
+                <li><a href="https://support.taxjar.com/category/233-taxjar-api" target="_blank">Support</a></li>
               </ul>
             </nav>
           </div>

--- a/source/partials/_sidebar.erb
+++ b/source/partials/_sidebar.erb
@@ -7,7 +7,7 @@
   <ul>
     <input id="docsearch-mobile" placeholder="Search the docs...">
     <li>
-      <span>SmartCalcs</span>
+      <span>TaxJar API</span>
       <ul>
         <li><a href="https://www.taxjar.com/api">Pricing</a></li>
         <li><a href="/demo/">API Demo</a></li>

--- a/source/reference.md
+++ b/source/reference.md
@@ -1,6 +1,6 @@
 ---
 title: Sales Tax API Reference
-description: "Documentation and code examples for SmartCalcs, TaxJar's sales tax API."
+description: "Documentation and code examples for TaxJar's sales tax API."
 preferred_url: https://developers.taxjar.com/api/reference/
 
 language_tabs:


### PR DESCRIPTION
TaxJar is going through a bit of a rebranding:

**SmartCalcs Sales Tax API** is now simplified to **TaxJar Sales Tax API** or **TaxJar API**.