### PR TITLE
Update API sign-up links

### DIFF
--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -68,7 +68,7 @@ $ curl "API_ENDPOINT" \
 
 > Make sure to replace `9e0cd62a22f451701f29c3bde214` with your API key.
 
-TaxJar uses API keys to allow access to the API. If you're new to TaxJar, you'll need to [sign up for an account](https://app.taxjar.com/api_sign_up/basic/) to get your API key. Otherwise, [log in](https://app.taxjar.com) and go to *Account > API Access* to generate a new API token.
+TaxJar uses API keys to allow access to the API. If you're new to TaxJar, you'll need to [sign up for an account](https://app.taxjar.com/api_sign_up/) to get your API key. Otherwise, [log in](https://app.taxjar.com) and go to *Account > API Access* to generate a new API token.
 
 TaxJar expects the API key to be included in all API requests to the server using a header like the following:
 

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -63,7 +63,7 @@ under the License.
             <nav>
               <ul>
                 <li><a href="https://app.taxjar.com/sign_in/" class="btn">Log In</a></li>
-                <li><a href="https://app.taxjar.com/api_sign_up/basic/" class="btn cta">Get API Token</a></li>
+                <li><a href="https://app.taxjar.com/api_sign_up/" class="btn cta">Get API Token</a></li>
               </ul>
               <ul class="navbar-responsive">
                 <li><a href="#" class="btn navbar-toggle">Menu</a></li>

--- a/source/partials/_sidebar.erb
+++ b/source/partials/_sidebar.erb
@@ -1,5 +1,5 @@
 <div class="sidebar__cta">
-  <a href="https://app.taxjar.com/api_sign_up/basic/" class="btn cta trial-link">Get API Token</a>
+  <a href="https://app.taxjar.com/api_sign_up/" class="btn cta trial-link">Get API Token</a>
   <a href="https://app.taxjar.com" class="btn"><b>Log In</b></a>
 </div><br>
 

--- a/source/reference.md
+++ b/source/reference.md
@@ -65,4 +65,4 @@ We currently provide API clients for the following languages:
 - <img class="client-icon" src="../images/clients/java-logo.svg" width="16"> [Java Sales Tax API](https://github.com/taxjar/taxjar-java) *via Maven & Gradle as `com.taxjar:taxjar-java`*
 - <img class="client-icon" src="../images/clients/go-logo.svg" width="16"> [Go Sales Tax API](https://github.com/taxjar/taxjar-go) *as `taxjar` from `github.com/taxjar/taxjar-go`*
 
-Before getting started, you'll need to [sign up for TaxJar](https://app.taxjar.com/api_sign_up/basic/) and get an API key. If you have any questions or would like to request support for a new client language, feel free to [contact us](mailto:support@taxjar.com).
+Before getting started, you'll need to [sign up for TaxJar](https://app.taxjar.com/api_sign_up/) and get an API key. If you have any questions or would like to request support for a new client language, feel free to [contact us](mailto:support@taxjar.com).


### PR DESCRIPTION
The sign-up link for the API has changed to [`app.taxjar.com/api_sign_up/`](app.taxjar.com/api_sign_up/).