### PR TITLE
INT-894 Add TLS 1.2 test snippet for cURL

### DIFF
--- a/source/includes/_security.md
+++ b/source/includes/_security.md
@@ -2,6 +2,14 @@
 
 > TLS 1.2 Test Snippet
 
+```shell
+# Run the following command and ensure that your system is using
+# cURL version 7.34.0 or higher
+curl --version
+# Additionally, check that your OpenSSL version is 1.0.1 or higher with
+openssl version -a
+```
+
 ```ruby
 require 'taxjar'
 client = Taxjar::Client.new(api_key: '[YOUR TAXJAR TOKEN]')


### PR DESCRIPTION
We have TLS 1.2 test snippets in the security guide for all API client languages we support; however, we don't yet include one for cURL.

This PR adds such an example so developers will know if the libraries necessary to access the TaxJar API via cURL require updating.