### PR TITLE
Clarify only new TaxJar accounts will start defaulting

### DIFF
--- a/source/includes/_api_version.md
+++ b/source/includes/_api_version.md
@@ -103,5 +103,5 @@ TaxJar has introduced API versioning to deliver enhanced validations and feature
 For more details, see the [API Changelog](https://developers.taxjar.com/api/reference/#changelog).
 
 <aside class="notice">
-Effective July 1, 2021, all TaxJar accounts will default to version '2020-08-07'.
+Effective July 1, 2021, all new TaxJar accounts will default to version '2020-08-07'.
 </aside>


### PR DESCRIPTION
Following up on #92 
Clarifying that only new TaxJar accounts will start defaulting to the newer API version. 