### PR TITLE
Update description for PTC 40030 in _categories.md

### DIFF
--- a/source/includes/endpoints/_categories.md
+++ b/source/includes/endpoints/_categories.md
@@ -223,7 +223,7 @@ $ curl https://api.taxjar.com/v2/categories \
     {
       "name": "Food & Groceries",
       "product_tax_code": "40030",
-      "description": "Food for humans consumption, unprepared"
+      "description": "Food for human consumption, unprepared"
     },
     {
       "name": "Soft Drinks",


### PR DESCRIPTION
Updated the description for Food & Groceries (40030) to read "Food for **human** consumption" rather than "Food for **humans** consumption".