### PR TITLE
Update example requests with new default version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     dotenv (1.0.2)
     erubis (2.7.0)
     execjs (2.5.2)
-    ffi (1.9.8)
+    ffi (1.15.5)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt

--- a/source/includes/_api_version.md
+++ b/source/includes/_api_version.md
@@ -7,7 +7,7 @@ require "taxjar"
 client = Taxjar::Client.new(api_key: "9e0cd62a22f451701f29c3bde214")
 
 client.set_api_config('headers', {
-  'x-api-version' => '2020-08-07'
+  'x-api-version' => '2022-01-24'
 })
 ```
 
@@ -16,7 +16,7 @@ import taxjar
 client = taxjar.Client(api_key='9e0cd62a22f451701f29c3bde214')
 
 client.set_api_config('headers', {
-  'x-api-version': '2020-08-07'
+  'x-api-version': '2022-01-24'
 })
 ```
 
@@ -28,7 +28,7 @@ const client = new Taxjar({
 });
 
 client.setApiConfig('headers', {
-  'x-api-version': '2020-08-07'
+  'x-api-version': '2022-01-24'
 });
 ```
 
@@ -37,7 +37,7 @@ require __DIR__ . '/vendor/autoload.php';
 $client = TaxJar\Client::withApiKey("9e0cd62a22f451701f29c3bde214");
 
 $client->setApiConfig('headers', [
-  'x-api-version' => '2020-08-07'
+  'x-api-version' => '2022-01-24'
 ]);
 ```
 
@@ -46,7 +46,7 @@ using Taxjar;
 var client = new TaxjarApi("9e0cd62a22f451701f29c3bde214");
 
 client.setApiConfig("headers", new Dictionary<string, string> {
-  { "x-api-version", "2020-08-07" }
+  { "x-api-version", "2022-01-24" }
 });
 ```
 
@@ -60,11 +60,11 @@ public class ApiVersionExample {
 
     public static void main(String[] args) {
         Map<String, Object> params = new HashMap<>();
-        params.put("x-api-version", "2020-08-07");
+        params.put("x-api-version", "2022-01-24");
 
         Taxjar client = new Taxjar("9e0cd62a22f451701f29c3bde214", params);
 
-        client.setApiConfig("x-api-version", "2020-08-07");
+        client.setApiConfig("x-api-version", "2022-01-24");
     }
 
 }
@@ -81,7 +81,7 @@ func main() {
     })
 
     client.Headers = map[string]interface{}{
-      "x-api-version": "2020-08-07",
+      "x-api-version": "2022-01-24",
     }
 }
 ```
@@ -89,7 +89,7 @@ func main() {
 ```shell
 $ curl "API_ENDPOINT" \
   -H "Authorization: Bearer 9e0cd62a22f451701f29c3bde214" \
-  -H "x-api-version: 2020-08-07"
+  -H "x-api-version: 2022-01-24"
 ```
 
 TaxJar has introduced API versioning to deliver enhanced validations and features. To take advantage of an API version, `'x-api-version'` must be specified in API call request headers.
@@ -105,5 +105,4 @@ For more details, see the [API Changelog](https://developers.taxjar.com/api/refe
 
 <aside class="notice">
 Effective February 3, 2022, all new TaxJar accounts will default to version '2022-01-24'.<br>
-Effective July 1, 2021, all new TaxJar accounts will default to version '2020-08-07'.
 </aside>


### PR DESCRIPTION
Updates requested by @pingt in https://docs.google.com/document/d/1N-EAcznC-RUnY0hMyqC6_FWNbrHEHBqhiGRmuN4YNoY/edit?disco=AAAAUllVpE0 as follow up to the new API version doc updates in https://github.com/taxjar/taxjar-api-docs/pull/103

https://deploy-preview-104--taxjar-api-docs.netlify.app/reference/

```
Ping T
2:05 PM Feb 4
👍. Looks good. Couple of small things:
1. Can we update the API version to 2022 for the example headers in the right language window pane?  For ex Python is:
client.set_api_config('headers', {
'x-api-version': '2020-08-07'

2.  Blue tooltip:
Effective February 3, 2022, all new TaxJar accounts will default to version ‘2022-01-24’.
Effective July 1, 2021, all new TaxJar accounts will default to version ‘2020-08-07’.

Is it important for users to know that we defaulted to 2020 version in July 2021?  If so, maybe we can strike out so it's more clear of the Feb 3rd defaults.  Otherwise maybe we could just remove the July 2021 line?
```

<img width="935" alt="Screen Shot 2022-02-11 at 1 52 44 PM" src="https://user-images.githubusercontent.com/88851167/153660167-8a715025-1871-4bbb-b0d4-6cb958e2d001.png">
<img width="951" alt="Screen Shot 2022-02-11 at 1 52 09 PM" src="https://user-images.githubusercontent.com/88851167/153660189-b8433458-4a27-47e0-9cef-28d4e8e042d2.png">
<img width="934" alt="Screen Shot 2022-02-11 at 1 53 53 PM" src="https://user-images.githubusercontent.com/88851167/153660318-fcae423e-915f-4280-a176-52d2b94246f0.png">
