### PR TITLE
Update guides.md to distinguish Magento 2 and 1

### DIFF
--- a/source/guides.md
+++ b/source/guides.md
@@ -317,8 +317,8 @@ We currently provide official integrations for the following platforms:
 Our Magento sales tax extensions currently support Magento 1.7.x - 1.9.x and Magento 2.0+. The TaxJar API is fully integrated for checkout calculations and zip-based rate imports as a fallback.
 
 - Install our [Magento 2](https://marketplace.magento.com/taxjar-module-taxjar.html) or [Magento 1](https://marketplace.magento.com/taxjar-taxjar-salestaxautomation.html) extension from Magento Marketplace
-- Get started and learn how it works with our [Extension Guide](https://www.taxjar.com/guides/integrations/magento/)
-- Browse the code in our [GitHub Repository](https://github.com/taxjar/taxjar-magento-extension)
+- Get started and learn how it works with our [Magento 2 Extension Guide](https://www.taxjar.com/guides/integrations/magento2/) or [Magento 1 Extension Guide](https://www.taxjar.com/guides/integrations/magento/)
+- Browse the code in the Github Repository for our [Magento 2 Extension](https://github.com/taxjar/taxjar-magento2-extension) or [Magento 1 Extension](https://github.com/taxjar/taxjar-magento-extension)
 
 ## NetSuite
 


### PR DESCRIPTION
Adds links to distinguish between the guides and code for Magento 2 and Magento 1